### PR TITLE
updated build to match OffSec

### DIFF
--- a/build-vbox.sh
+++ b/build-vbox.sh
@@ -191,7 +191,7 @@ while getopts ":a:b:D:o:f:hkL:m:P:r:s:S:T:U:v:x:z" opt; do
         (U) USERPASS=$OPTARG ;;
         (v) VARIANT=$OPTARG ;;
         (x) VERSION=$OPTARG ;;
-        (z) ZIP=true ;;
+        (z) ZIP=false ;;
         (*) echo "$USAGE" >&2; exit 1 ;;
     esac
 done

--- a/build-vmware.sh
+++ b/build-vmware.sh
@@ -191,7 +191,7 @@ while getopts ":a:b:D:o:f:hkL:m:P:r:s:S:T:U:v:x:z" opt; do
         (U) USERPASS=$OPTARG ;;
         (v) VARIANT=$OPTARG ;;
         (x) VERSION=$OPTARG ;;
-        (z) ZIP=true ;;
+        (z) ZIP=false ;;
         (*) echo "$USAGE" >&2; exit 1 ;;
     esac
 done

--- a/build.sh
+++ b/build.sh
@@ -191,7 +191,7 @@ while getopts ":a:b:D:o:f:hkL:m:P:r:s:S:T:U:v:x:z" opt; do
         (U) USERPASS=$OPTARG ;;
         (v) VARIANT=$OPTARG ;;
         (x) VERSION=$OPTARG ;;
-        (z) ZIP=true ;;
+        (z) ZIP=false ;;
         (*) echo "$USAGE" >&2; exit 1 ;;
     esac
 done

--- a/tlosint.yaml
+++ b/tlosint.yaml
@@ -27,6 +27,10 @@ actions:
     components: [ main, contrib, non-free ]
     keyring-file: kali-archive-keyring.gpg
 
+  - description: "Install usr-is-merged (cf. debos #361 and #362)"
+    action: apt
+    packages: [ usr-is-merged ]
+
   - description: "Preseed package configuration"
     action: run
     chroot: true


### PR DESCRIPTION
Current main branch was failing, compared our yaml to OffSecs and noticed this block was in theirs but not ours. Seems to be succeeding after the change. 

Additionally, we've modified the build script to automatically compress the final files. Added in the ability to not compress via the `-z` flag. Essentially reversing the original flags from OffSec that did not compress by default. The default behavior of our script will be to compress, but for the purposes of testing we have the option to not compress. 