### PR TITLE
Install-tools.sh update

### DIFF
--- a/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
+++ b/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
@@ -8,24 +8,13 @@ echo "export PATH=$PATH:$HOME/.local/bin" >> ~/.zshrc
 export PATH=$PATH:$HOME/.local/bin
 
 sudo apt install sherlock -y
-sudo apt install -y
-sudo apt install python3-shodan -y
-sudo apt install spiderfoot -y
-sudo apt install sherlock -y
 sudo apt install maltego -y
-sudo apt install python3-shodan -y
-sudo apt install theharvester -y
 sudo apt install webhttrack -y
 sudo apt install outguess -y
 sudo apt install stegosuite -y
-sudo apt install wireshark -y
-sudo apt install openvpn -y
 sudo apt install metagoofil -y
 sudo apt install eyewitness -y
 sudo apt install exifprobe -y
-sudo apt install ruby-bundler -y
-sudo apt install recon-ng -y
-sudo apt install cherrytree -y
 sudo apt install instaloader -y
 sudo apt install photon -y
 sudo apt install sublist3r -y
@@ -36,7 +25,6 @@ sudo apt install finalrecon -y
 sudo apt install cargo -y
 sudo apt install pkg-config -y
 sudo apt install npm -y
-sudo apt install curl -y
 
 
 pip3 install --upgrade tweepy

--- a/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
+++ b/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
@@ -25,18 +25,19 @@ sudo apt install finalrecon -y
 sudo apt install cargo -y
 sudo apt install pkg-config -y
 sudo apt install npm -y
+sudo apt install python3-tweepy -y
+sudo apt install python3-fake_useragent -y
 
+sudo apt install pipx -y
+echo '\nPATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 
-pip3 install --upgrade tweepy
-pip3 install --upgrade exifread 
-pip3 install --upgrade youtube-dl
-pip3 install --upgrade fake_useragent
+pipx install youtube-dl
+pipx install h8mail
+pipx install shodan
+pipx install toutatis
+pipx install yt-dlp
+
 pip3 install --upgrade dnsdumpster
-pip3 install --upgrade h8mail
-pip3 install --upgrade shodan
-pip3 install --upgrade toutatis
-pip3 install --upgrade yt-dlp
-
 
 mkdir -p ~/github-tools
 cd ~/github-tools

--- a/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
+++ b/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
@@ -43,12 +43,11 @@ mkdir -p ~/github-tools
 cd ~/github-tools
 
 
-# sn0int, will come back to this and test the install better
-#sudo apt install debian-keyring
-#gpg -a --export --keyring /usr/share/keyrings/debian-maintainers.gpg kpcyrd@archlinux.org | sudo tee /etc/apt/trusted.gpg.d/apt-vulns-sexy.gpg
-#echo deb http://apt.vulns.sexy stable main | sudo tee /etc/apt/sources.list.d/apt-vulns-sexy.list
-#sudo apt update
-#sudo apt install sn0int
+# Install sn0int
+wget -O- https://apt.vulns.sexy/kpcyrd.pgp | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt-vulns-sexy.gpg
+echo deb http://apt.vulns.sexy stable main | sudo tee /etc/apt/sources.list.d/apt-vulns-sexy.list
+sudo apt update
+sudo apt install sn0int
 
 
 


### PR DESCRIPTION
1. Remove duplicates and already installed packages

1. Move Python packages install to apt or pipx
https://www.kali.org/blog/python-externally-managed/

1. Fix the sn0int install