### PR TITLE
Update install-tools.sh and Chromium policy to Reflect Current Vortimo Installation Method

### DIFF
--- a/overlays/tl-overlays/etc/chromium/policies/managed/test_policy.json
+++ b/overlays/tl-overlays/etc/chromium/policies/managed/test_policy.json
@@ -23,7 +23,7 @@
   "ExtensionInstallForcelist": [
     "cjpalhdlnbpafiamejdnhcphjbkeiagm",
     "gcbommkclmclpchllfjekcdonpmejbdp",
-    "engmbahfeipfbgcjnjgekgkpmdfhkicn"
+    "mnakbpdnkedaegeiaoakkjafhoidklnf"
   ],
   "HomepageIsNewTabPage": true,
   "HomepageLocation": "https://tracelabs.org/",

--- a/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
+++ b/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
@@ -64,13 +64,6 @@ sudo npm i -g tiktok-scraper
 
 
 
-# Install Vortimo
-vortimo_debian=$(curl -s https://www.vortimo.com/down/ | grep --color -E "[^\S ]*Vortimo-.*[0-9].deb" -o | awk -F '="' '{print $2}')
-vortimo_package=$(echo $vortimo_debian | awk -F '/' '{print $NF}')
-curl -O -s $vortimo_debian
-sudo dpkg -i $vortimo_package
-rm $vortimo_package
-
 
 # TJ Null Jopolin Notebook
 if [ -d "~/Desktop/TJ-OSINT-Notebook" ]; then


### PR DESCRIPTION
## Summary
This Pull Request updates the `install-tools.sh` script and Chromium policy, primarily to address the issue of the outdated Vortimo Debian package URL and to update the Chromium extension list. Since Vortimo no longer offers a Debian package and has shifted to providing a web app and Chrome extension, scripts required modifications to reflect these changes.

## Changes Made
- Removed the code segment attempting to download and install the Vortimo `.deb` package, as this method is obsolete.
- Updated the Chrome Web Store URLs in the `ExtensionInstallForcelist` to include the correct Vortimo Chrome extension. 

## Rationale
The modifications ensure that users of the TL OSINT VM can successfully install and use the latest version of Vortimo. Additionally, updating the Chromium extension list to include the correct Vortimo extension aligns with the current offerings and enhances user experience by providing direct access to the latest tools.

## Additional Notes
These changes reflect Vortimo's transition from a standalone application to a browser-based service, ensuring the TL OSINT VM remains updated with the latest tool versions and methodologies in the field of OSINT.
