### PR TITLE
Optimize Dockerfile by cleaning up temporary files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/kalilinux/kali-rolling
 
 RUN apt-get update \
- && apt-get install  -y \
+ && apt-get install -y \
     bmap-tools debos linux-image-amd64 p7zip parted qemu-utils xz-utils zerofree user-mode-linux libslirp-helper \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Enhanced the Dockerfile by adding a cleanup step to remove temporary directories and package lists after package installation. This change aims to reduce the Docker image size by eliminating unnecessary files, leading to a cleaner and slightly more efficient image.