### PR TITLE
Fix install-tools.sh by adding updated Kali GPG key import (#74)

### DIFF
--- a/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
+++ b/overlays/tl-overlays/etc/skel/Desktop/install-tools.sh
@@ -46,8 +46,23 @@ display_log_contents() {
 
 # Function to update and upgrade the system
 update_system() {
-    sudo apt-get update || { echo "Failed to update package lists"; add_to_error_log "Failed to update package lists"; }
-    sudo apt-get dist-upgrade -y || { echo "Failed to upgrade the system"; add_to_error_log "Failed to upgrade the system"; }
+    echo "[*] Checking for updated Kali GPG key..."
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://archive.kali.org/archive-key.asc | sudo gpg --dearmor -o /etc/apt/keyrings/kali-archive-keyring.gpg || {
+        echo "Failed to import Kali GPG key"
+        add_to_error_log "Failed to import Kali GPG key"
+    }
+
+    echo "[*] Running apt update..."
+    sudo apt-get update || {
+        echo "Failed to update package lists"
+        add_to_error_log "Failed to update package lists"
+    }
+
+    sudo apt-get dist-upgrade -y || {
+        echo "Failed to upgrade the system"
+        add_to_error_log "Failed to upgrade the system"
+    }
 }
 
 


### PR DESCRIPTION
This pull request resolves [Issue #74](https://github.com/tracelabs/tlosint-vm/issues/74) by importing Kali Linux’s updated archive signing key before `apt-get update` is run inside `install-tools.sh`.

**Fix Summary:**
- Adds a step to import the key using `curl | gpg --dearmor`
- Ensures `apt` can securely update package lists again
- Keeps error logging consistent with the rest of the script

Without this fix, tool installations silently fail due to GPG signature errors and outdated repo keyrings.
