### PR TITLE
Handle builds without KVM

### DIFF
--- a/build-in-container.sh
+++ b/build-in-container.sh
@@ -23,14 +23,14 @@ else
 fi
 
 if [ -x /usr/bin/podman ]; then
-    PODMAN=podman
+    CONTAINER_ENGINE=podman
     # Add --user only if KVM is available (and we can safely map host user)
     if [[ -e /dev/kvm ]] && [ $(id -u) -eq 0 ]; then
         OPTS+=(--user "$(stat -c "%u:%g" .)")
     fi
     OPTS+=(--log-driver none) # suppress stdout in the journal
 elif [ -x /usr/bin/docker ]; then
-    PODMAN=docker
+    CONTAINER_ENGINE=docker
     if [[ -e /dev/kvm ]]; then
         OPTS+=(--user "$(stat -c "%u:%g" .)")
     fi
@@ -43,9 +43,9 @@ bold() { tput bold; echo "$@"; tput sgr0; }
 vrun() { bold "$" "$@"; "$@"; }
 vexec() { bold "$" "$@"; exec "$@"; }
 # build docker image if it doesn't exist
-if ! $PODMAN inspect --type image $IMAGE >/dev/null 2>&1; then
-    vrun $PODMAN build -t $IMAGE .
+if ! $CONTAINER_ENGINE inspect --type image $IMAGE >/dev/null 2>&1; then
+    vrun $CONTAINER_ENGINE build -t $IMAGE .
     echo
 fi
 # run the build script inside a container
-vexec $PODMAN run "${OPTS[@]}" $IMAGE ./build.sh "$@"
+vexec $CONTAINER_ENGINE run "${OPTS[@]}" $IMAGE ./build.sh "$@"

--- a/build-in-container.sh
+++ b/build-in-container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# checks kvm availability and sets container options appropriately
 # checks for either Podman or Docker, then builds the container image and runs it
 # normal args can be passed to the build.sh script, e.g. --no-cache
 set -eu
@@ -7,20 +8,32 @@ IMAGE=tlvm-builder
 OPTS=(
    --rm --interactive --tty --net host
     --privileged
-    --group-add $(stat -c '%g' /dev/kvm)
     --volume $(pwd):/recipes -v $(pwd)/images/:/images --workdir /recipes
 )
 
+# Check for KVM
+if [[ -e /dev/kvm ]]; then
+    KVM_GID=$(stat -c '%g' /dev/kvm)
+    OPTS+=(--group-add "$KVM_GID")
+    echo "KVM detected: container will use hardware acceleration."
+else
+    echo "WARNING: /dev/kvm not found. Falling back to software-emulated QEMU."
+    echo "The build will continue as root inside the container."
+    # Do not add --user, container defaults to root
+fi
 
 if [ -x /usr/bin/podman ]; then
     PODMAN=podman
-    if [ $(id -u) -eq 0 ]; then
-        OPTS+=(--user $(stat -c "%u:%g" .))
+    # Add --user only if KVM is available (and we can safely map host user)
+    if [[ -e /dev/kvm ]] && [ $(id -u) -eq 0 ]; then
+        OPTS+=(--user "$(stat -c "%u:%g" .)")
     fi
-    OPTS+=(--log-driver none)    # we don't want stdout in the journal
+    OPTS+=(--log-driver none) # suppress stdout in the journal
 elif [ -x /usr/bin/docker ]; then
     PODMAN=docker
-    OPTS+=(--user $(stat -c "%u:%g" .))
+    if [[ -e /dev/kvm ]]; then
+        OPTS+=(--user "$(stat -c "%u:%g" .)")
+    fi
 else
     echo "ERROR: No container engine detected, aborting." >&2
     exit 1


### PR DESCRIPTION
### Description

This PR allows container startup when KVM is not available.

Previously, the build would fail if `/dev/kvm` was missing or if `--group-add` was passed without a corresponding kvm group.

This change checks for KVM availability. If it’s not present, the container starts without `--group-add` and `--user`, allowing the build to fall back to host execution.

### Testing Notes

With KVM available: Verify that builds still succeed, and `--group-add` & `--user` options are applied.

Without KVM: Verified that builds proceed without KVM, falling back gracefully without requiring User-Mode Linux.

Check that the VM images are generated successfully in both scenarios.

#### Housekeeping

Renames `PODMAN` var to `CONTAINER_ENGINE`.  