### PR TITLE
Add sn0int build deps

### DIFF
--- a/scripts/tlosint-tools.sh
+++ b/scripts/tlosint-tools.sh
@@ -107,6 +107,7 @@ install_base_packages() {
     ca-certificates apt-transport-https software-properties-common gnupg
     curl wget git jq unzip zip xz-utils coreutils moreutils ripgrep fzf gawk
     build-essential pkg-config make gcc g++ libc6-dev
+    libsqlite3-dev libsodium-dev libseccomp-dev
     python3 python3-venv python3-pip python3-setuptools python3-dev pipx
     golang-go libssl-dev
     openjdk-11-jdk maven


### PR DESCRIPTION
## Summary

sn0int currently fails to build on a `kali-core` derived QubesOS template VM. Adding these dependencies allows the build to complete successfully, adding support for QubesOS without impacting other functionality.

## Type of change

- [ ] Enhancement / improvement
- [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
- [X] Bug fix
- [ ] Documentation
- [ ] CI / tooling / refactor

## Related issue(s)

- #114  

## Testing

- Created a fresh template VM from `kali-core` template
- Ran `tlosint-tools.sh`
- Verified sn0int validation passed

## Additional context

Noting that I seem to have encountered this because `apt.vulns.sexy` migrated to `apt.vulns.xyz`. I'll submit a separate PR to handle that change.
