### PR TITLE
Add tlosint-tools.sh as a release artifact

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,12 +1,11 @@
 name: Releases
 
-on: 
+on:
   push:
     tags:
-    - '*'
+      - "*"
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -16,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build OVA
-        run:  |
+        run: |
           sudo apt update
           sudo apt -y install debos p7zip qemu-utils zerofree
           cd $GITHUB_WORKSPACE
@@ -27,10 +26,11 @@ jobs:
           docker run --rm --interactive --net host --privileged --group-add $(stat -c '%g' /dev/kvm) --volume $(pwd):/recipes -v $(pwd)/images/:/images --workdir /recipes tlvm-builder ./build.sh -v virtualbox -f ova
           docker run --rm --interactive --net host --privileged --group-add $(stat -c '%g' /dev/kvm) --volume $(pwd):/recipes -v $(pwd)/images/:/images --workdir /recipes tlvm-builder ./build.sh -v vmware -f vmware
 
-
       - name: Release with Notes
         uses: softprops/action-gh-release@v1
         with:
-          files: "images/*.*"
+          files: |
+            images/*.*
+            scripts/tlosint-tools.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Trace Labs OSINT VM — Pull Request Template

This template helps keep PRs focused and easy to review.
-->

## Summary

Includes the standalone OSINT setup script (`scripts/tlosint-tools.sh`) as a downloadable asset in GitHub releases.
This allows users to grab just the tooling script without downloading the full VM image and is useful for those who want to set up OSINT tools on an existing Kali installation.

## Type of change

<!-- Pick one. If more than one applies, it might need to be split. -->

- [x] Enhancement / improvement
- [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
- [ ] Bug fix
- [ ] Documentation
- [ ] CI / tooling / refactor
