### PR TITLE
Fix releases container permissions for bind-mounted /recipes

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
           set -euo pipefail
 
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends debos p7zip qemu-utils zerofree
+          sudo apt-get install -y --no-install-recommends debos p7zip qemu-utils zerofree e2fsprogs
           sudo rm -rf /var/lib/apt/lists/*
 
           docker build -t tlvm-builder .

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -29,6 +29,7 @@ jobs:
           docker build -t tlvm-builder .
 
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
             --device /dev/kvm \
             --group-add "$(stat -c '%g' /dev/kvm)" \
             -v "$(pwd):/recipes" \
@@ -36,6 +37,7 @@ jobs:
             tlvm-builder ./build.sh -v virtualbox -f ova
 
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
             --device /dev/kvm \
             --group-add "$(stat -c '%g' /dev/kvm)" \
             -v "$(pwd):/recipes" \


### PR DESCRIPTION
The Dockerfile's CIS-hardened USER (tlosint, uid 1000) can't write to the host-owned bind mount.