### PR TITLE
phase out dev branch in favor of main + feature branches

### DIFF
--- a/.github/ISSUE_TEMPLATE/🚀-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/🚀-release-checklist.md
@@ -8,14 +8,12 @@ labels: kind/release
 Release Owner: [@username](https://github.com/username)
 Release Date: yyyy-mm-dd
 
-### Pre-Release
+## Pre-Release
 
-- [ ] Ensure CI is passing on the `dev` branch
-- [ ] PR `dev` into `main`
 - [ ] Build full VM images (VirtualBox + VMware)
 - [ ] Generate SHA256 checksums for both images
 
-### Release Tagging & Publishing
+## Release Tagging & Publishing
 
 - [ ] Select a version tag matching the format (`YYYY.MM`)
 - [ ] Tag the `main` branch (`git checkout main && git tag <version> && git push origin <version>`)
@@ -29,7 +27,7 @@ Release Date: yyyy-mm-dd
 
 Once published, the release is considered official.
 
-### Post-Release
+## Post-Release
 
 - [ ] Make an announcement in the `#tools-n-tech` channel in the Trace Labs Discord
 - [ ] Monitor early user feedback.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 <!--
-Trace Labs OSINT VM — Pull Request Template
-
-This template helps keep PRs focused and easy to review.
+Trace Labs OSINT VM — Pull Request Template. This template helps keep PRs focused and easy to review.
 -->
 
 ## Summary
@@ -12,31 +10,21 @@ This template helps keep PRs focused and easy to review.
 
 <!-- Pick one. If more than one applies, it might need to be split. -->
 
-- [ ] Enhancement / improvement
+- [ ] Software Update (enhancement / bug fix / refactor)
 - [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
-- [ ] Bug fix
 - [ ] Documentation
-- [ ] CI / tooling / refactor
 
 ## Related issue(s)
 
-<!-- 
-If the PR closes an issue, reference it:
-  Closes #123
-  Fixes #123
-  Resolves #123
-  
-If it’s related but not closing, note that too.
-Make sure the issue is assigned to you in GitHub.
--->
+<!-- If the PR closes an issue, reference it: Closes #123. If it’s related but not closing, note that too. Make sure the issue is assigned to you in GitHub.-->
 
-- 
+---------------
 
 ## Testing
 
 <!-- How you verified the change. -->
 
-- 
+---------------
 
 ## Additional context
 

--- a/.github/workflows/ensure-vm-builds.yml
+++ b/.github/workflows/ensure-vm-builds.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 # This action will trigger whenever main gets updated
 # success on this action would imply success when we push a release and files are generated
-# triggers on PRs or direct commits to main or dev branches
+# triggers on PRs or direct commits to main
 on:
   push:
     paths-ignore:
@@ -13,7 +13,6 @@ on:
       - LICENSE
     branches:
       - main
-      - dev # Added the dev branch here
   pull_request:
     paths-ignore:
       - ".github/CODEOWNERS"
@@ -22,7 +21,6 @@ on:
       - LICENSE
     branches:
       - main
-      - dev # And here as well
 
 jobs:
   run-docker:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,21 +11,21 @@ This file gives AI assistants project-specific context so suggestions stay align
 
 ## Branch & Release Model
 
-- **All PRs target `dev`.** Nothing goes directly to `main` for normal changes.
-- Flow: `PR → dev` → full VM build on every push to `dev` → when stable, maintainers merge `dev` → `main` → tag → release.
-- **`main`** is only updated from `dev` after the full build passes. Releases are tagged from `main` (e.g. `2025.08`).
-- Do not suggest merging to `main` or changing the release cadence; that is maintainer-owned. Hotfixes follow the process in `docs/RELEASES.md`.
+- **All PRs target `main`** from short-lived feature branches (e.g. `feature/my-change`).
+- Flow: `feature branch → PR → main` → full VM build on every push to `main` → push a version tag → release triggered automatically.
+- Releases are triggered by pushing a version tag (e.g. `2025.08`) to `main`.
+- Do not suggest using a `dev` branch or changing the release cadence; that is maintainer-owned. Hotfixes follow the process in `docs/RELEASES.md`.
 
 ## Build & Tooling
 
-- **Build:** debos reads `tlosint.yaml`; build is typically run via Docker (e.g. `build-in-container.sh`). CI runs full VM builds on `dev` and `main` (see `.github/workflows/ensure-vm-builds.yml`).
+- **Build:** debos reads `tlosint.yaml`; build is typically run via Docker (e.g. `build-in-container.sh`). CI runs minimal VM builds on `main` and open PRs targeting `main` (see `.github/workflows/ensure-vm-builds.yml`).
 - **Adding tools:** New tools must be proposed via a **Tool Request** issue and follow **docs/TOOLING_POLICY.md**. The VM is curated for OSINT; we avoid bloat and duplicate functionality. Do not suggest adding tools without referencing the tooling policy and evaluation criteria.
 - **Scripts:** Scripts in `scripts/` are either run by debos (see `tlosint.yaml`) or are standalone utilities (e.g. `tlosint-tools.sh`). Check the playbook and CONTRIBUTING before assuming a script is part of the image build.
 
 ## Key Files & Docs
 
 | Purpose | Location |
-|--------|----------|
+| -------- | ---------- |
 | Contributing, workflow, PR guidelines | `docs/CONTRIBUTING.md` |
 | Release process, hotfixes | `docs/RELEASES.md` |
 | Tool evaluation and request process | `docs/TOOLING_POLICY.md` |
@@ -36,7 +36,7 @@ This file gives AI assistants project-specific context so suggestions stay align
 
 ## Conventions to Follow
 
-- **One logical change per PR.** PRs should target `dev`.
+- **One logical change per PR.** PRs should target `main` from a feature branch.
 - **No built VM images or large binaries** in PRs.
 - Reference issues with `Closes #123` (or similar) when a PR fixes an issue.
 - When suggesting new tools or packages, remind the user to open a Tool Request issue and to follow docs/TOOLING_POLICY.md (relevance, license, no overlap, etc.).
@@ -45,7 +45,7 @@ This file gives AI assistants project-specific context so suggestions stay align
 
 ## What Not to Do
 
-- Do not suggest merging feature PRs to `main` or bypassing `dev`.
+- Do not suggest using a `dev` branch or bypassing the feature-branch → `main` PR workflow.
 - Do not suggest adding tools without going through the Tool Request process and TOOLING_POLICY criteria.
 - Do not assume `tlosint-tools.sh` runs during the VM build; it is a post-import user script.
 - Do not propose changes that conflict with the tooling policy (e.g. non-OSINT tools, duplicate tools, license-incompatible tools).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,16 +26,14 @@ By participating in this project, you agree to abide by our [Code of Conduct](..
 
 ### Summary
 
-`PR → dev (can break) → full build passes → dev → main → tag → release`
+`feature branch → PR → main → tag → release`
 
 ### Branch & CI Workflow
 
-- All PRs are merged into the **`dev`** branch.  
+- All PRs are merged into **`main`** from short-lived feature branches.  
 - PRs must pass linting and smoke tests (no full 15-min builds on PRs).  
-- Every push to `dev` triggers a **full VM build**; if it fails, `dev` must be fixed before anything moves to `main`.  
-- The **`main`** branch only receives changes from `dev` once the full build is passing.  
-- On a scheduled cadence (e.g., every three months), maintainers merge `dev` into `main` and tag a release, which triggers the automated release workflow.
-- Automated bi-weekly builds (coming soon) will trigger a release if the build passes.
+- Every push to `main` triggers a **minimal VM build**
+- Releases are triggered by pushing a version tag (e.g., `2025.08`) to `main`, which starts the automated release workflow.
 
 Read more about the release process in [RELEASES.md](./RELEASES.md).
 
@@ -44,7 +42,7 @@ Read more about the release process in [RELEASES.md](./RELEASES.md).
 - Keep PRs focused: **one change, feature, or fix per PR**.  
 - If your PR closes an issue, include `Closes #123` in the description.  
 - Do **not** include built VM images or large binaries in PRs.
-- PRs should target the `dev` branch.
+- PRs should target `main` from a feature branch (e.g., `feature/add-my-tool`).
 
 ---
 
@@ -71,4 +69,4 @@ If you want to propose a new tool:
 
 1. Open an issue describing the tool and its OSINT use case.  
 2. Follow the guidelines in [TOOLING_POLICY.md](TOOLING_POLICY.md).
-3. Once approved, submit a PR targeting `dev` with your proposed changes.
+3. Once approved, submit a PR targeting `main` with your proposed changes.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -9,7 +9,16 @@ Release owners and timelines are proposed and confirmed during our quarterly pla
 
 ## Overview
 
-Development happens in the **`dev`** branch. Once `dev` is stable and the full VM build passes, changes are merged into **`main`**. Tagging `main` triggers the automated release workflow.
+Development happens in short-lived **feature branches**. Once a feature branch is reviewed and CI passes, it is merged into **`main`** via a PR. Pushing a version tag triggers the automated release workflow.
+
+Releases are tied to a specific commit, not necessarily the HEAD of `main`. If `main` has commits that are not ready to ship, tag the last commit you want to include:
+
+```sh
+git tag <version> <commit-sha>
+git push origin <version>
+```
+
+This means unfinished or in-progress changes can continue landing on `main` without blocking a release.
 
 We follow a predictable release cadence, with additional hotfix releases when needed. The process is mostly automated but includes a small number of manual steps.
 
@@ -72,16 +81,15 @@ Hotfixes address urgent issues such as upstream breakage, major tool failures, o
 ### Hotfix Policy
 
 - Hotfix PRs should be **minimal** and focused solely on the fix.  
-- Hotfix PRs land in `dev`, then are cherry-picked or merged into `main`.  
+- Hotfix PRs are submitted directly to `main` from a short-lived `hotfix/` branch.  
 - Hotfix releases should not include unrelated changes.
 
 ### Hotfix Workflow
 
 1. Identify the issue requiring a hotfix.  
-2. Submit a PR to `dev` with the minimal fix.  
-3. After merging, wait for CI to run a full build on `dev` to confirm stability.  
-4. Cherry-pick the fix into `main`.  
-5. Tag a hotfix release (e.g., `yyyy.mm.1`).  
-6. Follow the release procedure to publish the hotfix release.
+2. Create a `hotfix/<description>` branch from `main` and submit a PR.  
+3. After merging, wait for CI to confirm the full build is stable on `main`.  
+4. Push a hotfix release tag (e.g., `yyyy.mm.1`) to `main` to trigger the automated release workflow.  
+5. Follow the release procedure to publish the hotfix release.
 
 Hotfixes should be used sparingly and only when necessary.


### PR DESCRIPTION
## Summary

This PR updates all documentation and CI configuration to reflect the new branching strategy: feature branches merge directly into main. Also, simplifies the PR template.

## Type of change

<!-- Pick one. If more than one applies, it might need to be split. -->

- [ ] Enhancement / improvement
- [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
- [ ] Bug fix
- [x] Documentation
- [x] CI / tooling / refactor

