### PR TITLE
Use GPG instead of Sequoia for dearmor

### DIFF
--- a/scripts/tlosint-tools.sh
+++ b/scripts/tlosint-tools.sh
@@ -151,7 +151,7 @@ setup_sn0int_repo() {
   log "[*] Setting up apt.vulns.xyz for sn0int"
   run "${SUDO} apt-get install -y curl sq"
   if [[ ! -f /etc/apt/trusted.gpg.d/apt-vulns-xyz.gpg ]]; then
-    run "curl -sSf https://apt.vulns.xyz/kpcyrd.pgp | sq dearmor | ${SUDO} tee /etc/apt/trusted.gpg.d/apt-vulns-xyz.gpg > /dev/null"
+    run "curl -sSf https://apt.vulns.xyz/kpcyrd.pgp | gpg --dearmor | ${SUDO} tee /etc/apt/trusted.gpg.d/apt-vulns-xyz.gpg > /dev/null"
   else
     log "[*] apt.vulns.xyz key already present"
   fi


### PR DESCRIPTION
<!--
Trace Labs OSINT VM — Pull Request Template. This template helps keep PRs focused and easy to review.
-->

## Summary

`tlosint-tools.sh` currently relies on a call to `sq dearmor` [here](https://github.com/tracelabs/tlosint-vm/blob/main/scripts/tlosint-tools.sh#L154).

The command `sq dearmor` was removed between versions [0.26.0](https://docs.rs/crate/sequoia-sq/0.26.0) and [1.0.0](https://docs.rs/crate/sequoia-sq/1.0.0). The current version installed by Kali at the time of this writing is 1.3.2. 

This change replaces the call to `sq dearmor` with a call to `gpg --dearmor` as recommended by the maintainer of the repository `apt.vulns.xyz` [here](https://apt.vulns.xyz/).

## Type of change

<!-- Pick one. If more than one applies, it might need to be split. -->

- [x] Software Update (enhancement / bug fix / refactor)
- [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
- [ ] Documentation

## Related issue(s)

Closes #162 

---------------

## Testing

- Imported a fresh copy of the Base VM version 2025.12
- Cloned `https://github.com/tracelabs/tlosint-vm`
- Checked out branch `u/use-gpg-dearmor`
- Executed script `tlosint-tools.sh`
- Executed update script
- Verified the update was successful

---------------

## Additional context

None available
