### PR TITLE
Updates ensure-vm-builds.yml with the new GPG key for Debian

### DIFF
--- a/.github/workflows/ensure-vm-builds.yml
+++ b/.github/workflows/ensure-vm-builds.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Verify GPG key exists in image
         run: |
           echo "Checking image contents..."
-          docker run --rm tlvm-builder:latest ls -lah /opt/kali-archive-keyring.gpg || {
+          docker run --rm tlvm-builder:latest ls -lah /opt/debian-archive-keyring.gpg || {
             echo "ERROR: GPG key not found in image!"
             docker run --rm tlvm-builder:latest ls -lah /opt/ || echo "Cannot list /opt"
             exit 1


### PR DESCRIPTION
## Summary

Updates the ensure-vm-builds.yml workflow to check for the Debian GPG key instead of the Kali one.

## Type of change

- [x] Software Update (enhancement / bug fix / refactor)
- [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
- [ ] Documentation

## Related issue(s)

Closes #167 

---------------

## Testing

Will have to test this using GitHub Actions.