### PR TITLE
Update finish-install.sh for POSIX compatibility.

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,3 +16,5 @@ jobs:
       - uses: actions/checkout@v5
       - name: Run Shellcheck
         uses: ludeeus/action-shellcheck@2.0.0
+	with:
+	  severity: warning

--- a/scripts/finish-install.sh
+++ b/scripts/finish-install.sh
@@ -12,7 +12,7 @@ set -e
 configure_apt_sources_list() {
     # The deb822 format (Types:/URIs:/Suites:) only works in
     # /etc/apt/sources.list.d/*.sources, not /etc/apt/sources.list.
-    local sources=/etc/apt/sources.list.d/debian.sources
+    sources=/etc/apt/sources.list.d/debian.sources
 
     : > /etc/apt/sources.list
 
@@ -37,6 +37,7 @@ Components: main contrib non-free non-free-firmware
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 END
     apt-get update
+    unset sources
 }
 
 get_user_list() {


### PR DESCRIPTION
## Summary

This PR is to fix finish-install.sh to ensure it is POSIX compatible since local is not a type of variable in POSIX sh.

## Type of change

- [x] Software Update (enhancement / bug fix / refactor)
- [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
- [ ] Documentation

## Related issue(s)

Closes #169

---------------

## Testing

Used Shellcheck's online tester and validated that build is still successful