### PR TITLE
feat: add Phantom Tide as Firefox managed bookmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ chmod +x scripts/tlosint-tools.sh
 - [Alias Generator (OSRFramework)](https://github.com/i3visio/osrframework)
 - [Usufy (OSRFramework)](https://github.com/i3visio/osrframework)
 
+**Maritime / Geospatial**
+
+- [Phantom Tide](https://phantom.labs.jamessawyer.co.uk/) (web — Firefox bookmark)
+
 **Other Tools**
 
 - [Photon](https://github.com/s0md3v/Photon)

--- a/scripts/tlosint-tools.sh
+++ b/scripts/tlosint-tools.sh
@@ -771,6 +771,7 @@ harden_firefox() {
       { "name": "WHOIS", "url": "https://who.is/" },
       { "name": "GreyNoise Viz", "url": "https://viz.greynoise.io/" },
       { "name": "OSINT Framework", "url": "https://osintframework.com/" },
+      { "name": "Phantom Tide", "url": "https://phantom.labs.jamessawyer.co.uk/" },
       { "name": "Trace Labs CTF", "url": "https://www.tracelabs.org/initiatives/search-party-ctf" }
     ]
   }


### PR DESCRIPTION
## Summary

Adds Phantom Tide (`https://phantom.labs.jamessawyer.co.uk/`) to the Firefox managed bookmarks injected by `tlosint-tools.sh`, and adds a new **Maritime / Geospatial** section to the README. Phantom Tide is a cross-domain maritime and airspace OSINT platform covering vessel tracking, AIS anomaly detection, sanctions monitoring, restricted airspace crossings, and hotspot ranking across open signals. No local install required — follows the same pattern as Shodan, Censys, and GreyNoise.

Hope I have done this right.

## Type of change

- [x] New OSINT Tool

## Related issue(s)

Closes #176

## Testing

- Confirmed the bookmark entry follows the exact JSON format of existing entries in the `ManagedBookmarks` array
- No shell logic changed — purely a data addition within the heredoc policy block
- Live tool verified accessible at `https://phantom.labs.jamessawyer.co.uk/`
- README updated with new Maritime / Geospatial section as required for new tool PRs

## Additional context

Maritime and airspace OSINT is currently a gap in the VM's bookmark set. Phantom Tide fills that with a single unified surface rather than requiring analysts to cross-reference multiple separate feeds. Public docs and release notes: https://github.com/tg12/phantomtide