### PR TITLE
[Feature] Improved Distribution Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use this if you just want to import and go.
 - **Full Build Releases (includes pre-installed OSINT tools)**
   - [**Click here to download the VirtualBox OVA**](https://vm-downloads.tracelabs.org/2026.5/tl-osint-2026.5-vbox-amd64-full.ova) (2026.05 VM Release)
   - [**Click here to download the VMware OVA**](https://vm-downloads.tracelabs.org/2026.5/tl-osint-2026.5-vmware-amd64-full.ova) (2026.05 VM Release)
-  - [**Click here to download the ARM64 qcow2 release supporting Apple silicon**](https://vm-downloads.tracelabs.org/2026.5/tl-osint-2026.5-vmware-amd64-full.ova) (2026.05 VM Release)
+  - [**Click here to download the ARM64 qcow2 release supporting Apple silicon**](https://vm-downloads.tracelabs.org/2026.5/tl-osint-2026.5-arm64-full.qcow2) (2026.05 VM Release)
 
  
 - **Checksums:**  

--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ The repository includes a [recipe file](./tlosint.yaml) to build a Linux OSINT D
 
 Use this if you just want to import and go.
 
-- **GitHub Releases (canonical):**  
-  https://github.com/tracelabs/tlosint-vm/releases (2026.05 VM release)
+- **Minimal Build (no tools) Releases (canonical):**  
+  - https://github.com/tracelabs/tlosint-vm/releases (2026.05 VM release)
 
-- **Mirror (Google)**  
-  - [**Click here to download the VirtualBox OVA**](https://drive.google.com/file/d/1DLupmDIKR2REdDvdG2zi1oSYRYcEPb5G/view?usp=sharing) (2026.05 VM Release)
-  - [**Click here to download the VMware OVA**](https://drive.google.com/file/d/1W5EGG4ZgSEs1dsph87fEmnb7Krhb2b94/view?usp=sharing) (2026.05 VM Release)
+- **Full Build Releases (includes pre-installed OSINT tools)**
+  - [**Click here to download the VirtualBox OVA**](https://vm-downloads.tracelabs.org/2026.5/tl-osint-2026.5-vbox-amd64-full.ova) (2026.05 VM Release)
+  - [**Click here to download the VMware OVA**](https://vm-downloads.tracelabs.org/2026.5/tl-osint-2026.5-vmware-amd64-full.ova) (2026.05 VM Release)
+  - [**Click here to download the ARM64 qcow2 release supporting Apple silicon**](https://vm-downloads.tracelabs.org/2026.5/tl-osint-2026.5-vmware-amd64-full.ova) (2026.05 VM Release)
+
  
-  - **Checksums:**  
+- **Checksums:**  
   - VMware: `d078731e2940e670bdf5af5c20d9602bdbbb0680df59a80259048b2cdcbf078a`  
   - VirtualBox: `7377109bad57162d45f76c9892305b09897d4a925cfb9db1688e2ca12f0d4187`
+  - Apple Silicon (qcow2): `a718a38acac863443eeecaaf000cb598fc881f887a2e3b22bde6c5c52ee3b0ab`
 
 ### Verify integrity
 


### PR DESCRIPTION
## Summary

This PR updates the download links for the full build of the 2026.05 VM release to point to the new domain `vm-downloads.tracelabs.org` rather than Google Drive. I've also updated the language in the README file to clarify the difference between the minimal and full VM builds.

## Type of change

- [x] Enhancement / improvement
- [ ] New OSINT Tool <!-- If checked, the README must be updated with the new tool. -->
- [ ] Bug fix
- [ ] Documentation
- [x] CI / tooling / refactor

## Related issue(s)

- Closes #185 

## Testing

- I've clicked each download link to verify the correct files are downloaded successfully

## Additional context

This change means some minor changes to our post-build distribution workflow and I'm not sure where to document them. Files can be uploaded to the R2 bucket using `rclone`. Each file should be uploaded using something like:

`rclone copy -P --s3-upload-cutoff=0 --s3-chunk-size=100M --include tl-osint-2026.5-arm64-full.qcow2 ./ r2:tlosint-vm-downloads/2026.5/`

Or just stage all the files in a single directory and upload them with:

`rclone copy -P --s3-upload-cutoff=0 --s3-chunk-size=100M --include "tl-osint-2026.5-*.ova" ./ r2:tlosint-vm-downloads/2026.5/`

Ensuring the build number is updated where appropriate.

I'm around to help clarify what needs to be done next time there's a release to upload