### PR TITLE
feat: add maigret to the OSINT toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ chmod +x tlosint-tools.sh
 ### What the script does
 
 - Refreshes the **Debian archive keyring** and applies updates
-- Installs a curated **OSINT toolset** (Shodan CLI, Sherlock, PhoneInfoga, SpiderFoot, sn0int, Metagoofil, Sublist3r, steghide/stegseek, StegOSuite, exiftool, tor, torbrowser-launcher, translate-shell, etc.)
+- Installs a curated **OSINT toolset** (Shodan CLI, Sherlock, Maigret, PhoneInfoga, SpiderFoot, sn0int, Metagoofil, Sublist3r, steghide/stegseek, StegOSuite, exiftool, tor, torbrowser-launcher, translate-shell, etc.)
 - Adds a **Self-Heal & Update** shortcut to the Desktop
 - Applies **Firefox hardening** (delete cookies/history on shutdown, block geolocation/mic/camera prompts by default, stronger tracking protection, preload OSINT bookmarks)
 
@@ -229,6 +229,7 @@ chmod +x scripts/tlosint-tools.sh
 **Usernames**
 
 - [Alias Generator (OSRFramework)](https://github.com/i3visio/osrframework)
+- [Maigret](https://github.com/soxoj/maigret)
 - [Usufy (OSRFramework)](https://github.com/i3visio/osrframework)
 
 **Other Tools**

--- a/scripts/tlosint-tools-debian-arm64.sh
+++ b/scripts/tlosint-tools-debian-arm64.sh
@@ -53,7 +53,7 @@ ensure_global_symlinks() {
 }
 
 ensure_pipx_wrappers() {
-  local bins=(shodan sherlock metagoofil sublist3r sf.py)
+  local bins=(shodan sherlock maigret metagoofil sublist3r sf.py)
   for b in "${bins[@]}"; do
     [[ -x "${TARGET_HOME}/.local/bin/${b}" ]] && write_wrapper "/usr/local/bin/${b}" "${TARGET_HOME}/.local/bin/${b}"
   done
@@ -708,6 +708,9 @@ install_tools_from_list() {
   # sherlock
   pipx_user_install_or_upgrade "sherlock" "git+https://github.com/sherlock-project/sherlock.git"
 
+  # maigret
+  pipx_user_install_or_upgrade "maigret" "maigret"
+
   # PhoneInfoga (Go)
   if command -v go >/dev/null 2>&1; then
     go_install_if_missing "github.com/sundowndev/phoneinfoga/v2/cmd/phoneinfoga@latest" "phoneinfoga"
@@ -963,7 +966,7 @@ JSON
 post_install_checks() {
   log "[*] Post-install sanity checks"
   local missing=()
-  for b in shodan sherlock phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide theHarvester h8mail httrack yt-dlp instaloader; do
+  for b in shodan sherlock maigret phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide theHarvester h8mail httrack yt-dlp instaloader; do
     command -v "$b" >/dev/null 2>&1 || missing+=("$b")
   done
   command -v spiderfoot >/dev/null 2>&1 || command -v sf.py >/dev/null 2>&1 || missing+=("spiderfoot/sf.py")
@@ -985,6 +988,7 @@ usage_hints() {
 Usage:
 - Shodan:          shodan init <API_KEY>   (or set SHODAN_API_KEY before running)
 - SpiderFoot UI:   spiderfoot -l 127.0.0.1:5001  (open http://127.0.0.1:5001)
+- Maigret:         maigret <username> --html   (reports land in ./reports)
 - StegHide:        steghide embed -cf cover.jpg -ef secret.txt -sf out.jpg
                    steghide extract -sf out.jpg
 - StegSeek:        stegseek out.jpg /usr/share/wordlists/rockyou.txt

--- a/scripts/tlosint-tools-debian-arm64.sh
+++ b/scripts/tlosint-tools-debian-arm64.sh
@@ -988,7 +988,8 @@ usage_hints() {
 Usage:
 - Shodan:          shodan init <API_KEY>   (or set SHODAN_API_KEY before running)
 - SpiderFoot UI:   spiderfoot -l 127.0.0.1:5001  (open http://127.0.0.1:5001)
-- Maigret:         maigret <username> --html   (reports land in ./reports)
+- Maigret:         cd ~/osint-workspaces/<target> && maigret <username> --html
+                   (writes its reports into ./reports of the current directory)
 - StegHide:        steghide embed -cf cover.jpg -ef secret.txt -sf out.jpg
                    steghide extract -sf out.jpg
 - StegSeek:        stegseek out.jpg /usr/share/wordlists/rockyou.txt

--- a/scripts/tlosint-tools.sh
+++ b/scripts/tlosint-tools.sh
@@ -766,7 +766,8 @@ usage_hints() {
 Usage:
 - Shodan:          shodan init <API_KEY>   (or set SHODAN_API_KEY before running script)
 - SpiderFoot UI:   spiderfoot -l 127.0.0.1:5001  (open http://127.0.0.1:5001)
-- Maigret:         maigret <username> --html   (reports land in ./reports)
+- Maigret:         cd ~/osint-workspaces/<target> && maigret <username> --html
+                   (writes its reports into ./reports of the current directory)
 - StegHide:        steghide embed -cf cover.jpg -ef secret.txt -sf out.jpg
                    steghide extract -sf out.jpg
 - StegSeek:        stegseek out.jpg /usr/share/wordlists/rockyou.txt

--- a/scripts/tlosint-tools.sh
+++ b/scripts/tlosint-tools.sh
@@ -46,7 +46,7 @@ ensure_global_symlinks() {
   done
 }
 ensure_pipx_wrappers() {
-  local bins=(shodan sherlock metagoofil sublist3r sf.py)
+  local bins=(shodan sherlock maigret metagoofil sublist3r sf.py)
   for b in "${bins[@]}"; do
     [[ -x "${TARGET_HOME}/.local/bin/${b}" ]] && write_wrapper "/usr/local/bin/${b}" "${TARGET_HOME}/.local/bin/${b}"
   done
@@ -548,6 +548,9 @@ install_tools_from_list() {
   # Sherlock
   pipx_user_install_or_upgrade "sherlock" "git+https://github.com/sherlock-project/sherlock.git"
 
+  # Maigret
+  pipx_user_install_or_upgrade "maigret" "maigret"
+
   # PhoneInfoga
   if command -v go >/dev/null 2>&1; then
     go_install_if_missing "github.com/sundowndev/phoneinfoga/v2/cmd/phoneinfoga@latest" "phoneinfoga"
@@ -741,7 +744,7 @@ JSON
 post_install_checks() {
   log "[*] Post-install sanity checks"
   local missing=()
-  for b in shodan sherlock phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide; do
+  for b in shodan sherlock maigret phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide; do
     command -v "$b" >/dev/null 2>&1 || missing+=("$b")
   done
   command -v spiderfoot >/dev/null 2>&1 || command -v sf.py >/dev/null 2>&1 || missing+=("spiderfoot/sf.py")
@@ -763,6 +766,7 @@ usage_hints() {
 Usage:
 - Shodan:          shodan init <API_KEY>   (or set SHODAN_API_KEY before running script)
 - SpiderFoot UI:   spiderfoot -l 127.0.0.1:5001  (open http://127.0.0.1:5001)
+- Maigret:         maigret <username> --html   (reports land in ./reports)
 - StegHide:        steghide embed -cf cover.jpg -ef secret.txt -sf out.jpg
                    steghide extract -sf out.jpg
 - StegSeek:        stegseek out.jpg /usr/share/wordlists/rockyou.txt

--- a/scripts/tracelabs-vm-setup/tlosint-tools-deb.zsh
+++ b/scripts/tracelabs-vm-setup/tlosint-tools-deb.zsh
@@ -211,6 +211,12 @@ install_sherlock() {
   pipx_install "sherlock-project"
 }
 
+# Maigret (pipx)
+install_maigret() {
+  log "Installing maigret (pipx preferred)"
+  pipx_install "maigret"
+}
+
 # metagoofil (git + venv + reqs) + wrapper
 install_metagoofil() {
   log "Installing metagoofil"
@@ -638,6 +644,7 @@ validate_install() {
   check_cmd "sn0int" "sn0int"
   check_cmd "ExifTool" "exiftool"
   check_cmd "sherlock" "sherlock"
+  check_cmd "maigret" "maigret"
   check_cmd "metagoofil wrapper" "metagoofil"
   check_cmd "sublist3r wrapper" "sublist3r"
   check_cmd "steghide" "steghide"
@@ -730,6 +737,7 @@ main() {
   install_sn0int
   install_exiftool
   install_sherlock
+  install_maigret
   install_metagoofil
   install_sublist3r
   install_steghide


### PR DESCRIPTION
## Summary

Adds maigret to the OSINT toolset installed by `tlosint-tools.sh` and its
arm64 counterpart. It sits next to the existing sherlock line and installs
from PyPI rather than git HEAD, since maigret does tagged releases.

Opening this as a draft on purpose. Per TOOLING_POLICY.md the tool should get
`tool/accepted` first, and #191 is still in triage, so this is here to make
that step cheap rather than to jump the queue. Happy to close it if you'd
rather keep the queue clean until the quarterly review.

## Type of change

- [x] New OSINT Tool

## Related issue(s)

- Relates to #191 (maigret is the first entry under "Username & account
  enumeration"). Not using "Closes" since that issue covers 18 tools.

## Testing

- `shellcheck --severity=warning` on both scripts: clean, same as before the
  change.
- `pipx install maigret` then `maigret --site GitHub --no-recursion <user>`
  returns hits and writes a report. curl_cffi, the only dependency with a
  compiled component, ships manylinux wheels for both x86_64 and aarch64, so
  the arm64 script is covered too.

## Additional context

I'm the maigret upstream author.

There's a third installer, `scripts/tracelabs-vm-setup/tlosint-tools-deb.zsh`,
which I left alone since README and CONTRIBUTING only point at the other two.
Tell me if you want maigret there as well and I'll add it.
