### PR TITLE
SOCMINT Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ chmod +x tlosint-tools.sh
 
 - Refreshes the **Debian archive keyring** and applies updates
 - Installs a curated **OSINT toolset** (Shodan CLI, Sherlock, PhoneInfoga, SpiderFoot, sn0int, Metagoofil, Sublist3r, steghide/stegseek, StegOSuite, exiftool, tor, torbrowser-launcher, translate-shell, etc.)
+- Installs a **SOCMINT toolset** — username enumeration (maigret, WhatsMyName), platform collection (Instaloader, GHunt), media acquisition (yt-dlp, gallery-dl, streamlink, ffmpeg), capture & archiving (auto-archiver, monolith, gowitness, internetarchive, Carbon14, HTTrack), signal extraction (tesseract-ocr), and investigator OPSEC (mat2)
 - Adds a **Self-Heal & Update** shortcut to the Desktop
 - Applies **Firefox hardening** (delete cookies/history on shutdown, block geolocation/mic/camera prompts by default, stronger tracking protection, preload OSINT bookmarks)
 
@@ -156,6 +157,20 @@ chmod +x scripts/tlosint-tools.sh
 ./scripts/tlosint-tools.sh
 ```
 
+**Optional tools (opt-in)**
+
+Two tools are not installed by default and are enabled with an environment variable. Use `sudo -E` so the variable survives into the script:
+
+```bash
+# ArchiveBox — omitted by default because it pulls a large dependency tree
+# plus its own Chromium, which noticeably grows the VM image.
+TLOSINT_INSTALL_ARCHIVEBOX=1 sudo -E ./scripts/tlosint-tools.sh
+
+# twscrape — omitted by default pending a Trace Labs terms-of-service review.
+# It works by driving logged-in X/Twitter accounts; see docs/TOOLING_POLICY.md.
+TLOSINT_ENABLE_TWSCRAPE=1 sudo -E ./scripts/tlosint-tools.sh
+```
+
 **Resources**
 
 - [Trace Labs OSINT Field Manual](https://github.com/tracelabs/tofm/blob/main/tofm.md)
@@ -177,11 +192,21 @@ chmod +x scripts/tlosint-tools.sh
 
 - [OSINT Forensics Full Screen Capture](https://chromewebstore.google.com/detail/forensic-osint-full-page/jojaomahhndmeienhjihojidkddkahcn?pli=1)
 
+**Capture & Archiving**
+
+- [ArchiveBox](https://github.com/ArchiveBox/ArchiveBox) (opt-in — see "Optional tools" above)
+- [auto-archiver](https://github.com/bellingcat/auto-archiver)
+- [Carbon14](https://github.com/Lazza/Carbon14)
+- [gowitness](https://github.com/sensepost/gowitness)
+- [internetarchive (`ia`)](https://github.com/jjjake/internetarchive)
+- [monolith](https://github.com/Y2Z/monolith)
+
 **Data Analysis**
 
 - [DumpsterDiver](https://github.com/securing/DumpsterDiver)
 - [Exifprobe](https://github.com/hfiguiere/exifprobe)
 - [Stegosuite](https://github.com/osde8info/stegosuite)
+- [Tesseract OCR](https://github.com/tesseract-ocr/tesseract)
 
 **Domains**
 
@@ -191,9 +216,12 @@ chmod +x scripts/tlosint-tools.sh
 **Downloaders**
 
 - [Browse Mirrored Websites](http://www.httrack.com/)
+- [FFmpeg](https://ffmpeg.org/) (required by yt-dlp and Streamlink to merge video+audio)
+- [gallery-dl](https://github.com/mikf/gallery-dl)
 - [Metagoofil](https://github.com/opsdisk/metagoofil)
+- [Streamlink](https://github.com/streamlink/streamlink)
 - [WebHTTrack Website Copier](http://www.httrack.com/)
-- [Youtube-DL](https://github.com/ytdl-org/youtube-dl)
+- [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 
 **Email**
 
@@ -219,17 +247,26 @@ chmod +x scripts/tlosint-tools.sh
 
 **Social Media**
 
+- [GHunt](https://github.com/mxrch/GHunt)
 - [Instaloader](https://github.com/instaloader/instaloader)
 - [Twint](https://github.com/twintproject/twint) (Archived)
 - [Searchfy (OSRFramework)](https://github.com/i3visio/osrframework)
 - [Tiktok Scraper](https://github.com/drawrowfly/tiktok-scraper)
+- [twscrape](https://github.com/vladkens/twscrape) (opt-in — pending terms-of-service review)
 - [Twayback](https://github.com/humandecoded/twayback)
 - [Stweet](https://github.com/markowanga/stweet)
 
 **Usernames**
 
 - [Alias Generator (OSRFramework)](https://github.com/i3visio/osrframework)
+- [maigret](https://github.com/soxoj/maigret)
 - [Usufy (OSRFramework)](https://github.com/i3visio/osrframework)
+- [WhatsMyName-Python](https://github.com/C3n7ral051nt4g3ncy/WhatsMyName-Python)
+
+**Investigator OPSEC**
+
+- [mat2](https://0xacab.org/jvoisin/mat2) (metadata removal)
+- `shred` (secure file deletion; from coreutils)
 
 **Other Tools**
 

--- a/overlays/tl-overlays/etc/skel/Desktop/TL-Vault/VM Tool Reference.md
+++ b/overlays/tl-overlays/etc/skel/Desktop/TL-Vault/VM Tool Reference.md
@@ -51,6 +51,41 @@ phoneinfoga scan -n +1XXXXXXXXXX
 
 ---
 
+### maigret
+> Check a username against 3000+ sites and build a structured dossier, not just a hit list
+
+**Type:** `CLI` `Python` | **Use cases:** username search, account discovery, cross-platform profiling
+
+```bash
+maigret <username>                    # console report
+maigret <username> --html             # browsable HTML dossier
+maigret <username> --top-sites 500    # faster pass over the busiest sites
+```
+
+> [!tip] Tips
+> Broader than Sherlock — run both. `--html` writes a report you can attach to case notes. Add `--no-progressbar` when piping output to a file.
+
+[📄 Documentation](https://github.com/soxoj/maigret)
+
+---
+
+### WhatsMyName
+> Username enumeration driven by the community-maintained WhatsMyName dataset
+
+**Type:** `CLI` `Python` | **Use cases:** username search, account discovery
+
+```bash
+whatsmyname -u <username>
+whatsmyname -u <username> --html      # write an HTML report
+```
+
+> [!tip] Tips
+> Pulls the WebBreacher site list at runtime, so coverage stays current without reinstalling the tool. Good cross-check when maigret and Sherlock disagree.
+
+[📄 Documentation](https://github.com/C3n7ral051nt4g3ncy/WhatsMyName-Python)
+
+---
+
 ## 🔎 Recon
 
 ### sn0int
@@ -121,6 +156,23 @@ exiftool *.jpg                # batch process
 > Always run this first on any image from the subject — GPS data is gold for location pivots.
 
 [📄 Documentation](https://exiftool.org)
+
+---
+
+### Tesseract OCR
+> Pull text out of images — screenshots, signs in photos, scanned documents
+
+**Type:** `CLI` | **Use cases:** OCR, text from screenshots, signage in photos, scanned documents
+
+```bash
+tesseract image.png out && cat out.txt   # writes out.txt
+tesseract image.png -                    # print straight to stdout
+```
+
+> [!tip] Tips
+> Accuracy depends heavily on image quality — crop to the text and increase contrast first. Useful for reading usernames or phone numbers baked into a screenshot.
+
+[📄 Documentation](https://tesseract-ocr.github.io)
 
 ---
 
@@ -195,6 +247,224 @@ torsocks <command>   # route any CLI tool through Tor
 
 ---
 
+## 📱 Social Platforms
+
+### Instaloader
+> Download Instagram posts, stories, tagged media, and follower lists
+
+**Type:** `CLI` `Python` | **Use cases:** Instagram collection, post archiving, follower lists, story capture
+
+```bash
+instaloader profile <handle>                  # posts + profile pic
+instaloader --no-posts --stories <handle>     # stories only (needs login)
+instaloader --login <you> <handle>            # authenticated session
+```
+
+> [!warning] OPSEC
+> Logging in ties the collection to that account. Use a research account, never a personal one.
+
+[📄 Documentation](https://instaloader.github.io)
+
+---
+
+### GHunt
+> Turn a Gmail address into Google activity — Maps reviews, Photos, Calendar, YouTube
+
+**Type:** `CLI` `Python` | **Use cases:** Gmail-to-identity mapping, Google Maps reviews, Photos, Calendar
+
+```bash
+ghunt login                    # one-time browser cookie import
+ghunt email <address>
+ghunt gaia <gaia-id>
+ghunt drive <file-or-folder-id>
+```
+
+> [!warning] Requires credentials
+> GHunt does nothing until `ghunt login` imports cookies from a signed-in Google session. Use a research account. Until then the VM validator reports GHunt as "login deferred" — that is expected, not a broken install.
+
+[📄 Documentation](https://github.com/mxrch/GHunt)
+
+---
+
+## 🎥 Media & Capture
+
+### yt-dlp
+> Download video and audio from YouTube, TikTok, X, Instagram, Facebook, and hundreds more
+
+**Type:** `CLI` `Python` | **Use cases:** video download, evidence capture, audio extraction, metadata
+
+```bash
+yt-dlp <url>                              # best quality, merged
+yt-dlp -F <url>                           # list available formats
+yt-dlp --write-info-json --no-download <url>   # metadata only, no media
+```
+
+> [!tip] Tips
+> ffmpeg is installed, so yt-dlp merges the best separate video and audio streams automatically. `--write-info-json` captures upload time, uploader ID, and description — often more useful for an investigation than the video itself.
+
+[📄 Documentation](https://github.com/yt-dlp/yt-dlp)
+
+---
+
+### gallery-dl
+> Bulk-download image galleries and media from social and image-hosting sites
+
+**Type:** `CLI` `Python` | **Use cases:** image galleries, bulk media download, social media images
+
+```bash
+gallery-dl <url>
+gallery-dl --write-metadata <url>     # save per-file JSON metadata
+gallery-dl -g <url>                   # print direct media URLs only
+```
+
+> [!tip] Tips
+> Complements yt-dlp: yt-dlp for video, gallery-dl for image sets. `--write-metadata` preserves the post context alongside each file.
+
+[📄 Documentation](https://github.com/mikf/gallery-dl)
+
+---
+
+### Streamlink
+> Capture live streams to disk before they disappear
+
+**Type:** `CLI` `Python` | **Use cases:** live stream capture, real-time evidence, time-sensitive collection
+
+```bash
+streamlink <url> best -o capture.ts
+streamlink <url> --json                # list available streams
+```
+
+> [!tip] Tips
+> Live content is the most perishable evidence there is — start the capture first and sort out quality later. Uses ffmpeg for muxing.
+
+[📄 Documentation](https://streamlink.github.io)
+
+---
+
+### FFmpeg
+> Convert, trim, and extract frames from video and audio
+
+**Type:** `CLI` | **Use cases:** video conversion, frame extraction, audio extraction, trimming
+
+```bash
+ffmpeg -i in.mp4 -ss 00:01:30 -t 10 clip.mp4   # 10s clip from 1:30
+ffmpeg -i in.mp4 -vf fps=1 frame_%04d.png      # one frame per second
+ffmpeg -i in.mp4 -vn -acodec copy audio.m4a    # strip audio track
+```
+
+> [!tip] Tips
+> Also the dependency that lets yt-dlp and Streamlink merge separate video and audio streams. Extracting frames makes a video reverse-image-searchable.
+
+[📄 Documentation](https://ffmpeg.org/documentation.html)
+
+---
+
+### gowitness
+> Bulk-screenshot a list of URLs so many leads can be triaged at once
+
+**Type:** `CLI` `Go` | **Use cases:** bulk screenshots, lead triage, profile URL sweeps
+
+```bash
+gowitness scan single --url <url>
+gowitness scan file -f urls.txt          # one URL per line
+gowitness report server                  # browse results in a local web UI
+```
+
+> [!tip] Tips
+> Point it at a list of candidate profile URLs from a username search and review the screenshots instead of opening tabs one by one. Drives the system Chromium.
+
+[📄 Documentation](https://github.com/sensepost/gowitness)
+
+---
+
+## 🗄 Archiving
+
+### auto-archiver
+> Archive a social post with screenshot, metadata, and content hash in one command
+
+**Type:** `CLI` `Docker` | **Use cases:** social post archiving, evidence integrity, hashed captures
+
+```bash
+auto-archiver --help
+# Your current directory is mounted at /data inside the container.
+auto-archiver --config /data/orchestration.yaml
+```
+
+> [!tip] Tips
+> Runs as a Docker container, so paths must be relative to `/data`. The content hash it records is what makes the capture defensible later.
+
+[📄 Documentation](https://github.com/bellingcat/auto-archiver)
+
+---
+
+### monolith
+> Freeze a live page into one self-contained HTML file — images, CSS, and JS inlined
+
+**Type:** `CLI` `Rust` | **Use cases:** page snapshots, offline evidence, profile freezing
+
+```bash
+monolith <url> -o profile.html
+monolith -j <url> -o profile.html    # exclude JavaScript
+```
+
+> [!tip] Tips
+> One file, no external requests when reopened — much stronger evidence than a screenshot because the page text stays searchable and selectable.
+
+[📄 Documentation](https://github.com/Y2Z/monolith)
+
+---
+
+### internetarchive (`ia`)
+> Search, download from, and submit pages to the Internet Archive
+
+**Type:** `CLI` `Python` | **Use cases:** Wayback retrieval, archive submission, durable storage
+
+```bash
+ia search '<query>'
+ia download <identifier>
+ia configure                     # optional: log in for uploads
+```
+
+> [!tip] Tips
+> Check the Wayback Machine before assuming deleted content is gone. Submitting a live URL creates a third-party timestamped copy you do not control — useful corroboration.
+
+[📄 Documentation](https://archive.org/services/docs/api/internetarchive/)
+
+---
+
+### Carbon14
+> Estimate when web content was actually published or last changed
+
+**Type:** `CLI` `Python` | **Use cases:** content dating, timeline building, claim verification
+
+```bash
+carbon14 <url>
+```
+
+> [!tip] Tips
+> Useful when a post has no visible timestamp, or when the displayed date looks wrong. Treat the result as evidence for a timeline, not proof on its own.
+
+[📄 Documentation](https://github.com/Lazza/Carbon14)
+
+---
+
+### HTTrack
+> Mirror an entire website locally for offline review
+
+**Type:** `CLI` `GUI` | **Use cases:** site mirroring, offline review, bulk page capture
+
+```bash
+httrack <url> -O ./mirror
+webhttrack                        # GUI front-end
+```
+
+> [!tip] Tips
+> Set a depth limit on large sites or the mirror will run for a very long time. Best for small sites and forum threads.
+
+[📄 Documentation](https://www.httrack.com/html/index.html)
+
+---
+
 ## 🛠 Utilities
 
 ### translate-shell
@@ -209,6 +479,43 @@ trans :en -i input.txt               # translate a file
 ```
 
 [📄 Documentation](https://github.com/soimort/translate-shell)
+
+---
+
+## 🛡 Investigator OPSEC
+
+### mat2
+> Strip metadata from files before you share or submit them
+
+**Type:** `CLI` `Python` | **Use cases:** metadata removal, safe file sharing, OPSEC hygiene
+
+```bash
+mat2 --show evidence.jpg        # see what metadata is present
+mat2 evidence.jpg              # writes evidence.cleaned.jpg
+mat2 --inplace evidence.jpg     # overwrite the original
+```
+
+> [!warning] OPSEC
+> Anything you produce on this VM may carry your own metadata — usernames, paths, software versions. Run `--show` before sending a file outside the team.
+
+[📄 Documentation](https://0xacab.org/jvoisin/mat2)
+
+---
+
+### shred
+> Overwrite a file's contents before deleting it
+
+**Type:** `CLI` | **Use cases:** secure deletion, disposing of sensitive downloads
+
+```bash
+shred -u <file>            # overwrite, then remove
+shred -u -n 3 <file>       # three passes
+```
+
+> [!tip] Tips
+> Part of coreutils, already present. Note that on SSDs and copy-on-write filesystems overwriting in place is not guaranteed — full-disk encryption is the real protection.
+
+[📄 Documentation](https://www.gnu.org/software/coreutils/manual/html_node/shred-invocation.html)
 
 ---
 

--- a/overlays/tl-overlays/usr/share/Obsidian/TL-Obsidian-Template/VM Tool Reference.md
+++ b/overlays/tl-overlays/usr/share/Obsidian/TL-Obsidian-Template/VM Tool Reference.md
@@ -51,6 +51,41 @@ phoneinfoga scan -n +1XXXXXXXXXX
 
 ---
 
+### maigret
+> Check a username against 3000+ sites and build a structured dossier, not just a hit list
+
+**Type:** `CLI` `Python` | **Use cases:** username search, account discovery, cross-platform profiling
+
+```bash
+maigret <username>                    # console report
+maigret <username> --html             # browsable HTML dossier
+maigret <username> --top-sites 500    # faster pass over the busiest sites
+```
+
+> [!tip] Tips
+> Broader than Sherlock — run both. `--html` writes a report you can attach to case notes. Add `--no-progressbar` when piping output to a file.
+
+[📄 Documentation](https://github.com/soxoj/maigret)
+
+---
+
+### WhatsMyName
+> Username enumeration driven by the community-maintained WhatsMyName dataset
+
+**Type:** `CLI` `Python` | **Use cases:** username search, account discovery
+
+```bash
+whatsmyname -u <username>
+whatsmyname -u <username> --html      # write an HTML report
+```
+
+> [!tip] Tips
+> Pulls the WebBreacher site list at runtime, so coverage stays current without reinstalling the tool. Good cross-check when maigret and Sherlock disagree.
+
+[📄 Documentation](https://github.com/C3n7ral051nt4g3ncy/WhatsMyName-Python)
+
+---
+
 ## 🔎 Recon
 
 ### sn0int
@@ -121,6 +156,23 @@ exiftool *.jpg                # batch process
 > Always run this first on any image from the subject — GPS data is gold for location pivots.
 
 [📄 Documentation](https://exiftool.org)
+
+---
+
+### Tesseract OCR
+> Pull text out of images — screenshots, signs in photos, scanned documents
+
+**Type:** `CLI` | **Use cases:** OCR, text from screenshots, signage in photos, scanned documents
+
+```bash
+tesseract image.png out && cat out.txt   # writes out.txt
+tesseract image.png -                    # print straight to stdout
+```
+
+> [!tip] Tips
+> Accuracy depends heavily on image quality — crop to the text and increase contrast first. Useful for reading usernames or phone numbers baked into a screenshot.
+
+[📄 Documentation](https://tesseract-ocr.github.io)
 
 ---
 
@@ -195,6 +247,224 @@ torsocks <command>   # route any CLI tool through Tor
 
 ---
 
+## 📱 Social Platforms
+
+### Instaloader
+> Download Instagram posts, stories, tagged media, and follower lists
+
+**Type:** `CLI` `Python` | **Use cases:** Instagram collection, post archiving, follower lists, story capture
+
+```bash
+instaloader profile <handle>                  # posts + profile pic
+instaloader --no-posts --stories <handle>     # stories only (needs login)
+instaloader --login <you> <handle>            # authenticated session
+```
+
+> [!warning] OPSEC
+> Logging in ties the collection to that account. Use a research account, never a personal one.
+
+[📄 Documentation](https://instaloader.github.io)
+
+---
+
+### GHunt
+> Turn a Gmail address into Google activity — Maps reviews, Photos, Calendar, YouTube
+
+**Type:** `CLI` `Python` | **Use cases:** Gmail-to-identity mapping, Google Maps reviews, Photos, Calendar
+
+```bash
+ghunt login                    # one-time browser cookie import
+ghunt email <address>
+ghunt gaia <gaia-id>
+ghunt drive <file-or-folder-id>
+```
+
+> [!warning] Requires credentials
+> GHunt does nothing until `ghunt login` imports cookies from a signed-in Google session. Use a research account. Until then the VM validator reports GHunt as "login deferred" — that is expected, not a broken install.
+
+[📄 Documentation](https://github.com/mxrch/GHunt)
+
+---
+
+## 🎥 Media & Capture
+
+### yt-dlp
+> Download video and audio from YouTube, TikTok, X, Instagram, Facebook, and hundreds more
+
+**Type:** `CLI` `Python` | **Use cases:** video download, evidence capture, audio extraction, metadata
+
+```bash
+yt-dlp <url>                              # best quality, merged
+yt-dlp -F <url>                           # list available formats
+yt-dlp --write-info-json --no-download <url>   # metadata only, no media
+```
+
+> [!tip] Tips
+> ffmpeg is installed, so yt-dlp merges the best separate video and audio streams automatically. `--write-info-json` captures upload time, uploader ID, and description — often more useful for an investigation than the video itself.
+
+[📄 Documentation](https://github.com/yt-dlp/yt-dlp)
+
+---
+
+### gallery-dl
+> Bulk-download image galleries and media from social and image-hosting sites
+
+**Type:** `CLI` `Python` | **Use cases:** image galleries, bulk media download, social media images
+
+```bash
+gallery-dl <url>
+gallery-dl --write-metadata <url>     # save per-file JSON metadata
+gallery-dl -g <url>                   # print direct media URLs only
+```
+
+> [!tip] Tips
+> Complements yt-dlp: yt-dlp for video, gallery-dl for image sets. `--write-metadata` preserves the post context alongside each file.
+
+[📄 Documentation](https://github.com/mikf/gallery-dl)
+
+---
+
+### Streamlink
+> Capture live streams to disk before they disappear
+
+**Type:** `CLI` `Python` | **Use cases:** live stream capture, real-time evidence, time-sensitive collection
+
+```bash
+streamlink <url> best -o capture.ts
+streamlink <url> --json                # list available streams
+```
+
+> [!tip] Tips
+> Live content is the most perishable evidence there is — start the capture first and sort out quality later. Uses ffmpeg for muxing.
+
+[📄 Documentation](https://streamlink.github.io)
+
+---
+
+### FFmpeg
+> Convert, trim, and extract frames from video and audio
+
+**Type:** `CLI` | **Use cases:** video conversion, frame extraction, audio extraction, trimming
+
+```bash
+ffmpeg -i in.mp4 -ss 00:01:30 -t 10 clip.mp4   # 10s clip from 1:30
+ffmpeg -i in.mp4 -vf fps=1 frame_%04d.png      # one frame per second
+ffmpeg -i in.mp4 -vn -acodec copy audio.m4a    # strip audio track
+```
+
+> [!tip] Tips
+> Also the dependency that lets yt-dlp and Streamlink merge separate video and audio streams. Extracting frames makes a video reverse-image-searchable.
+
+[📄 Documentation](https://ffmpeg.org/documentation.html)
+
+---
+
+### gowitness
+> Bulk-screenshot a list of URLs so many leads can be triaged at once
+
+**Type:** `CLI` `Go` | **Use cases:** bulk screenshots, lead triage, profile URL sweeps
+
+```bash
+gowitness scan single --url <url>
+gowitness scan file -f urls.txt          # one URL per line
+gowitness report server                  # browse results in a local web UI
+```
+
+> [!tip] Tips
+> Point it at a list of candidate profile URLs from a username search and review the screenshots instead of opening tabs one by one. Drives the system Chromium.
+
+[📄 Documentation](https://github.com/sensepost/gowitness)
+
+---
+
+## 🗄 Archiving
+
+### auto-archiver
+> Archive a social post with screenshot, metadata, and content hash in one command
+
+**Type:** `CLI` `Docker` | **Use cases:** social post archiving, evidence integrity, hashed captures
+
+```bash
+auto-archiver --help
+# Your current directory is mounted at /data inside the container.
+auto-archiver --config /data/orchestration.yaml
+```
+
+> [!tip] Tips
+> Runs as a Docker container, so paths must be relative to `/data`. The content hash it records is what makes the capture defensible later.
+
+[📄 Documentation](https://github.com/bellingcat/auto-archiver)
+
+---
+
+### monolith
+> Freeze a live page into one self-contained HTML file — images, CSS, and JS inlined
+
+**Type:** `CLI` `Rust` | **Use cases:** page snapshots, offline evidence, profile freezing
+
+```bash
+monolith <url> -o profile.html
+monolith -j <url> -o profile.html    # exclude JavaScript
+```
+
+> [!tip] Tips
+> One file, no external requests when reopened — much stronger evidence than a screenshot because the page text stays searchable and selectable.
+
+[📄 Documentation](https://github.com/Y2Z/monolith)
+
+---
+
+### internetarchive (`ia`)
+> Search, download from, and submit pages to the Internet Archive
+
+**Type:** `CLI` `Python` | **Use cases:** Wayback retrieval, archive submission, durable storage
+
+```bash
+ia search '<query>'
+ia download <identifier>
+ia configure                     # optional: log in for uploads
+```
+
+> [!tip] Tips
+> Check the Wayback Machine before assuming deleted content is gone. Submitting a live URL creates a third-party timestamped copy you do not control — useful corroboration.
+
+[📄 Documentation](https://archive.org/services/docs/api/internetarchive/)
+
+---
+
+### Carbon14
+> Estimate when web content was actually published or last changed
+
+**Type:** `CLI` `Python` | **Use cases:** content dating, timeline building, claim verification
+
+```bash
+carbon14 <url>
+```
+
+> [!tip] Tips
+> Useful when a post has no visible timestamp, or when the displayed date looks wrong. Treat the result as evidence for a timeline, not proof on its own.
+
+[📄 Documentation](https://github.com/Lazza/Carbon14)
+
+---
+
+### HTTrack
+> Mirror an entire website locally for offline review
+
+**Type:** `CLI` `GUI` | **Use cases:** site mirroring, offline review, bulk page capture
+
+```bash
+httrack <url> -O ./mirror
+webhttrack                        # GUI front-end
+```
+
+> [!tip] Tips
+> Set a depth limit on large sites or the mirror will run for a very long time. Best for small sites and forum threads.
+
+[📄 Documentation](https://www.httrack.com/html/index.html)
+
+---
+
 ## 🛠 Utilities
 
 ### translate-shell
@@ -209,6 +479,43 @@ trans :en -i input.txt               # translate a file
 ```
 
 [📄 Documentation](https://github.com/soimort/translate-shell)
+
+---
+
+## 🛡 Investigator OPSEC
+
+### mat2
+> Strip metadata from files before you share or submit them
+
+**Type:** `CLI` `Python` | **Use cases:** metadata removal, safe file sharing, OPSEC hygiene
+
+```bash
+mat2 --show evidence.jpg        # see what metadata is present
+mat2 evidence.jpg              # writes evidence.cleaned.jpg
+mat2 --inplace evidence.jpg     # overwrite the original
+```
+
+> [!warning] OPSEC
+> Anything you produce on this VM may carry your own metadata — usernames, paths, software versions. Run `--show` before sending a file outside the team.
+
+[📄 Documentation](https://0xacab.org/jvoisin/mat2)
+
+---
+
+### shred
+> Overwrite a file's contents before deleting it
+
+**Type:** `CLI` | **Use cases:** secure deletion, disposing of sensitive downloads
+
+```bash
+shred -u <file>            # overwrite, then remove
+shred -u -n 3 <file>       # three passes
+```
+
+> [!tip] Tips
+> Part of coreutils, already present. Note that on SSDs and copy-on-write filesystems overwriting in place is not guaranteed — full-disk encryption is the real protection.
+
+[📄 Documentation](https://www.gnu.org/software/coreutils/manual/html_node/shred-invocation.html)
 
 ---
 

--- a/scripts/tlosint-tools-debian-arm64.sh
+++ b/scripts/tlosint-tools-debian-arm64.sh
@@ -47,13 +47,19 @@ symlink_if_exists() {
 
 ensure_global_symlinks() {
   local CARGODIR="${TARGET_HOME}/.cargo/bin"
-  for b in cargo rustc rustup sn0int; do
+  for b in cargo rustc rustup sn0int monolith; do
     command -v "$b" >/dev/null 2>&1 || symlink_if_exists "${CARGODIR}/${b}" "${b}"
   done
 }
 
 ensure_pipx_wrappers() {
-  local bins=(shodan sherlock metagoofil sublist3r sf.py)
+  # Binary names (not pipx package names): internetarchive ships `ia`,
+  # WhatsMyName-Python ships `whatsmyname`. Absent binaries are skipped, so the
+  # opt-in tools (archivebox, twscrape) are safe to list unconditionally.
+  local bins=(shodan sherlock metagoofil sublist3r sf.py
+              maigret whatsmyname instaloader ghunt
+              yt-dlp gallery-dl streamlink
+              ia carbon14 archivebox twscrape)
   for b in "${bins[@]}"; do
     [[ -x "${TARGET_HOME}/.local/bin/${b}" ]] && write_wrapper "/usr/local/bin/${b}" "${TARGET_HOME}/.local/bin/${b}"
   done
@@ -147,7 +153,16 @@ install_base_packages() {
     whiptail zenity chromium nodejs npm firefox-esr
     steghide stegseek stegosuite
     translate-shell
-    httrack yt-dlp instaloader
+    httrack
+    # SOCMINT support (issue #191). ffmpeg MUST land before yt-dlp/streamlink:
+    # without it yt-dlp silently returns single-stream (lower quality) media
+    # instead of merging best video+audio. main() runs install_base_packages
+    # before install_tools_from_list, so that ordering is already guaranteed.
+    # yt-dlp and instaloader moved to pipx (see install_tools_from_list) —
+    # Trixie's apt builds lag far behind upstream for fast-moving scrapers.
+    ffmpeg
+    tesseract-ocr tesseract-ocr-eng
+    mat2
   )
   local p
   for p in "${pkgs[@]}"; do
@@ -205,9 +220,20 @@ pipx_user_install_or_upgrade() {
 go_install_if_missing() {
   local module="$1"; local bin="${2:-}"; local name="$bin"
   if [[ -z "$name" ]]; then name="${module##*/}"; name="${name%@*}"; fi
-  if ! command -v "$name" >/dev/null 2>&1; then
-    run "env GOBIN=/usr/local/bin go install \"$module\""
+  command -v "$name" >/dev/null 2>&1 && return 0
+  # Build into a writable temp dir, then place the binary with elevated rights.
+  # Pointing GOBIN straight at /usr/local/bin fails with "permission denied"
+  # whenever this script is run from an unprivileged account, and building under
+  # sudo instead would discard the user's module/toolchain cache.
+  local tmp; tmp="$(mktemp -d)"
+  if run "env GOBIN=\"${tmp}\" go install \"$module\"" && [[ -x "${tmp}/${name}" ]]; then
+    ${SUDO} install -m 0755 "${tmp}/${name}" "/usr/local/bin/${name}" 2>>"$LOG_FILE" \
+      && log "[*] ${name} installed: /usr/local/bin/${name}" \
+      || logerr "Failed to install ${name} into /usr/local/bin"
+  else
+    logerr "go install failed for ${module}"
   fi
+  rm -rf "$tmp" || true
 }
 
 cargo_install_if_missing() {
@@ -499,6 +525,20 @@ maybe_init_shodan() {
   fi
 }
 
+# GHunt needs Google account cookies, which cannot be provisioned unattended.
+# Follow the Shodan precedent: install unconditionally, drop a marker so the
+# validator reports "deferred" rather than failing an otherwise-clean install.
+maybe_defer_ghunt_login() {
+  command -v ghunt >/dev/null 2>&1 || return 0
+  if [[ -d "${TARGET_HOME}/.malfrats/ghunt" ]]; then
+    log "[*] GHunt credentials already present"
+    return 0
+  fi
+  ${SUDO} mkdir -p /etc/osint 2>>"$LOG_FILE" || true
+  ${SUDO} bash -lc 'echo "no-credentials" > /etc/osint/skip-ghunt-login' 2>>"$LOG_FILE" || true
+  log "[*] GHunt login deferred (run: ghunt login)"
+}
+
 # theHarvester git clone + venv + pip install
 install_theharvester() {
   local dest="/opt/theHarvester"
@@ -698,6 +738,74 @@ install_stweet() {
     logerr "Stweet install failed (archived)"
 }
 
+# ---------- auto-archiver (Docker) ----------
+# Upstream ships a maintained image rather than a pip package suited to a VM
+# install, so mirror the Owlculus pattern: pull the image and expose a thin
+# wrapper that mounts the caller's cwd at /data for output.
+install_auto_archiver_docker() {
+  log "[*] Installing bellingcat/auto-archiver (Docker)"
+
+  install_docker_and_compose_if_missing
+
+  if ! command -v docker >/dev/null 2>&1; then
+    logerr "auto-archiver skipped: docker unavailable"
+    return 0
+  fi
+
+  # The upstream image may not publish a linux/arm64 manifest; keep this
+  # non-fatal so an ARM64 build still completes with everything else intact.
+  run "${SUDO} docker pull bellingcat/auto-archiver" \
+    || logerr "auto-archiver image pull failed (may be amd64-only on ARM64; wrapper still installed)"
+
+  ${SUDO} tee /usr/local/bin/auto-archiver >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# The current directory is mounted at /data inside the container; point
+# auto-archiver's config and output paths there.
+# Only allocate a TTY when there is one, so piping/redirecting still works.
+# Note: an `[[ ... ]] && ...` one-liner would abort under `set -e` whenever the
+# test fails, so branch explicitly.
+TTY_FLAGS=(-i)
+if [[ -t 0 && -t 1 ]]; then
+  TTY_FLAGS=(-i -t)
+fi
+exec docker run --rm "${TTY_FLAGS[@]}" -v "${PWD}:/data" bellingcat/auto-archiver "$@"
+EOF
+  ${SUDO} chmod 0755 /usr/local/bin/auto-archiver
+  ${SUDO} chown root:root /usr/local/bin/auto-archiver
+
+  log "[*] auto-archiver installed (wrapper: /usr/local/bin/auto-archiver)"
+}
+
+# ---------- ArchiveBox (opt-in) ----------
+# ArchiveBox pulls a large dependency tree plus its own Chromium, so it is
+# gated to keep the default VM image small.
+install_archivebox_optional() {
+  if [[ "${TLOSINT_INSTALL_ARCHIVEBOX:-0}" != "1" ]]; then
+    log "[*] ArchiveBox skipped (VM image size; set TLOSINT_INSTALL_ARCHIVEBOX=1 to install)"
+    return 0
+  fi
+  log "[*] Installing ArchiveBox (TLOSINT_INSTALL_ARCHIVEBOX=1)"
+  pipx_user_install_or_upgrade "archivebox" "archivebox"
+  [[ -x "${TARGET_HOME}/.local/bin/archivebox" ]] \
+    && write_wrapper "/usr/local/bin/archivebox" "${TARGET_HOME}/.local/bin/archivebox"
+}
+
+# ---------- twscrape (opt-in, policy-gated) ----------
+# twscrape works by driving logged-in X/Twitter accounts, which plausibly meets
+# the "violation of terms of service" disqualifier in docs/TOOLING_POLICY.md.
+# Left out of the default install pending a Trace Labs policy decision.
+install_twscrape_optional() {
+  if [[ "${TLOSINT_ENABLE_TWSCRAPE:-0}" != "1" ]]; then
+    log "[*] twscrape skipped — pending Trace Labs ToS review (docs/TOOLING_POLICY.md); set TLOSINT_ENABLE_TWSCRAPE=1 to install"
+    return 0
+  fi
+  log "[*] Installing twscrape (TLOSINT_ENABLE_TWSCRAPE=1 — operator accepted ToS risk)"
+  pipx_user_install_or_upgrade "twscrape" "git+https://github.com/vladkens/twscrape.git"
+  [[ -x "${TARGET_HOME}/.local/bin/twscrape" ]] \
+    && write_wrapper "/usr/local/bin/twscrape" "${TARGET_HOME}/.local/bin/twscrape"
+}
+
 # install all OSINT tools
 install_tools_from_list() {
   log "[*] Installing OSINT tools"
@@ -788,7 +896,41 @@ install_tools_from_list() {
   # Joplin (not availble for ARM64)
   install_joplin
 
-  # Stego tools 
+  # ---------- SOCMINT (issue #191) ----------
+  # apt-sourced members of this set (ffmpeg, tesseract-ocr, mat2, httrack) are
+  # handled in install_base_packages, which main() runs first.
+
+  # 1 · Username & account enumeration
+  pipx_user_install_or_upgrade "maigret" "maigret"
+  pipx_user_install_or_upgrade "whatsmyname-python" "git+https://github.com/C3n7ral051nt4g3ncy/WhatsMyName-Python.git"
+
+  # 2 · Platform-specific collection
+  pipx_user_install_or_upgrade "instaloader" "instaloader"
+  pipx_user_install_or_upgrade "ghunt" "ghunt"
+
+  # 3 · Media & evidence acquisition (ffmpeg from base packages)
+  pipx_user_install_or_upgrade "yt-dlp" "yt-dlp"
+  pipx_user_install_or_upgrade "gallery-dl" "gallery-dl"
+  pipx_user_install_or_upgrade "streamlink" "streamlink"
+
+  # 4 · Capture & archiving
+  pipx_user_install_or_upgrade "internetarchive" "internetarchive"   # provides `ia`
+  pipx_user_install_or_upgrade "carbon14" "git+https://github.com/Lazza/Carbon14.git"
+  # monolith and gowitness both build natively on arm64.
+  ensure_rust_cargo_available
+  cargo_install_if_missing "monolith"
+  symlink_if_exists "${TARGET_HOME}/.cargo/bin/monolith" "monolith"
+  # gowitness drives the chromium already in install_base_packages.
+  if command -v go >/dev/null 2>&1; then
+    go_install_if_missing "github.com/sensepost/gowitness@latest" "gowitness"
+  fi
+  install_auto_archiver_docker
+  install_archivebox_optional
+
+  # Opt-in / policy-gated
+  install_twscrape_optional
+
+  # Stego tools
   apt_try_install stegosuite || log "[*] StegOSuite not available; skipping."
   apt_try_install steghide || true
   apt_try_install stegseek || true
@@ -810,8 +952,11 @@ install_tools_from_list() {
   # guarantee shodan is reachable
   ensure_shodan_available
 
-  # Shodan init 
+  # Shodan init
   maybe_init_shodan
+
+  # GHunt needs Google cookies; defer like Shodan rather than failing
+  maybe_defer_ghunt_login
 }
 
 # OSINT updater script
@@ -837,8 +982,16 @@ apt_self_heal_update() {
   run "apt-get -y clean || true"
 }
 upgrade_pipx_tools() {
-  if command -v pipx >/dev/null 2>&1; then
-    log "[*] Upgrading pipx apps"
+  # This script runs as root (pkexec), but the pipx apps live in the target
+  # user's ~/.local/pipx — root's own pipx home is empty, so the upgrade has to
+  # be run as that user or it silently upgrades nothing. __TARGET_USER__ is
+  # substituted at install time.
+  local PIPX_USER="__TARGET_USER__"
+  if sudo -u "$PIPX_USER" bash -lc 'command -v pipx >/dev/null 2>&1'; then
+    log "[*] Upgrading pipx apps for ${PIPX_USER}"
+    run "sudo -u \"$PIPX_USER\" bash -lc 'pipx upgrade-all' || true"
+  elif command -v pipx >/dev/null 2>&1; then
+    log "[*] Upgrading pipx apps (root)"
     run "pipx upgrade-all || true"
   fi
   if [[ -x /opt/shodan-venv/bin/pip ]]; then
@@ -851,12 +1004,23 @@ upgrade_go_tools() {
     log "[*] Refreshing PhoneInfoga (Go)"
     run "env GOBIN=/usr/local/bin go install github.com/sundowndev/phoneinfoga/v2/cmd/phoneinfoga@latest || true"
     chmod 0755 /usr/local/bin/phoneinfoga 2>>"$LOG_FILE" || true
+    log "[*] Refreshing gowitness (Go)"
+    run "env GOBIN=/usr/local/bin go install github.com/sensepost/gowitness@latest || true"
+    chmod 0755 /usr/local/bin/gowitness 2>>"$LOG_FILE" || true
   fi
 }
 upgrade_rust_tools() {
   if command -v cargo >/dev/null 2>&1; then
     log "[*] Refreshing sn0int (Rust)"
     run "cargo install --locked sn0int"
+    log "[*] Refreshing monolith (Rust)"
+    run "cargo install --locked monolith || true"
+  fi
+}
+upgrade_docker_images() {
+  if command -v docker >/dev/null 2>&1; then
+    log "[*] Refreshing auto-archiver image"
+    run "docker pull bellingcat/auto-archiver || true"
   fi
 }
 main() {
@@ -865,10 +1029,13 @@ main() {
   upgrade_pipx_tools
   upgrade_go_tools
   upgrade_rust_tools
+  upgrade_docker_images
   log "==== OSINT Updater complete. See $LOG_FILE for details. ===="
 }
 main "$@"
 EOF
+  # Bake the target user into the updater (same placeholder trick as write_wrapper)
+  ${SUDO} sed -i "s#__TARGET_USER__#${TARGET_USER}#g" "$UPD"
   ${SUDO} chmod +x "$UPD"
   ${SUDO} chown root:root "$UPD"
 
@@ -963,7 +1130,12 @@ JSON
 post_install_checks() {
   log "[*] Post-install sanity checks"
   local missing=()
-  for b in shodan sherlock phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide theHarvester h8mail httrack yt-dlp instaloader; do
+  # Unconditional tools only — the opt-in pair (archivebox, twscrape) must not
+  # be reported missing on a default install.
+  for b in shodan sherlock phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide \
+           theHarvester h8mail httrack \
+           maigret whatsmyname instaloader ghunt yt-dlp gallery-dl streamlink \
+           ia carbon14 monolith gowitness ffmpeg tesseract mat2; do
     command -v "$b" >/dev/null 2>&1 || missing+=("$b")
   done
   command -v spiderfoot >/dev/null 2>&1 || command -v sf.py >/dev/null 2>&1 || missing+=("spiderfoot/sf.py")
@@ -989,6 +1161,30 @@ Usage:
                    steghide extract -sf out.jpg
 - StegSeek:        stegseek out.jpg /usr/share/wordlists/rockyou.txt
 - Translate:       trans -b :de "Hello, how are you?"
+
+SOCMINT:
+- maigret:         maigret <username> --html
+- WhatsMyName:     whatsmyname -u <username>
+- Instaloader:     instaloader profile <handle>
+- GHunt:           ghunt login        (then: ghunt email <address>)
+- yt-dlp:          yt-dlp <url>       (ffmpeg present: merges best video+audio)
+- gallery-dl:      gallery-dl <url>
+- streamlink:      streamlink <url> best -o capture.ts
+- monolith:        monolith <url> -o profile.html
+- gowitness:       gowitness scan file -f urls.txt
+- internetarchive: ia search '<query>'   /   ia download <identifier>
+- Carbon14:        carbon14 <url>
+- tesseract:       tesseract image.png out && cat out.txt
+- mat2:            mat2 --inplace evidence.jpg
+- HTTrack:         httrack <url> -O ./mirror
+- auto-archiver:   auto-archiver --help   (Docker; your cwd is mounted at /data)
+- shred:           shred -u <file>        (secure delete; from coreutils)
+
+Opt-in tools (not installed by default):
+- ArchiveBox:      TLOSINT_INSTALL_ARCHIVEBOX=1 sudo -E ./tlosint-tools-debian-arm64.sh
+                   (large dependency tree + its own Chromium)
+- twscrape:        TLOSINT_ENABLE_TWSCRAPE=1 sudo -E ./tlosint-tools-debian-arm64.sh
+                   (drives logged-in X accounts — review docs/TOOLING_POLICY.md first)
 
 Firefox:
 - about:policies shows hardened settings; OSINT bookmarks on toolbar.
@@ -1106,8 +1302,50 @@ validator() {
   show_ver theHarvester -h || true
   show_ver h8mail -h || true
   show_ver httrack --version || true
-  show_ver yt-dlp --version || true
+
+  # ---------- SOCMINT (issue #191) ----------
+  show_ver maigret --version || true
+  show_ver whatsmyname --help || true
   show_ver instaloader --version || true
+  show_ver yt-dlp --version || true
+  show_ver gallery-dl --version || true
+  show_ver streamlink --version || true
+  show_ver ffmpeg -version || true
+  show_ver ia --version || true
+  show_ver monolith --version || true
+  show_ver gowitness version || true
+  show_ver carbon14 --help || true
+  show_ver tesseract --version || true
+  show_ver mat2 --version || true
+
+  # GHunt: credential-dependent, same treatment as Shodan above
+  if has ghunt; then
+    if [[ -d "${REAL_HOME}/.malfrats/ghunt" ]]; then
+      ok "GHunt present and authenticated"
+    elif [[ -f /etc/osint/skip-ghunt-login ]]; then
+      ok "GHunt login deferred (no credentials provided; run: ghunt login)"
+    else
+      warn "GHunt not authenticated (run: ghunt login)"
+    fi
+  else
+    fail "ghunt not found on PATH"
+  fi
+
+  # auto-archiver runs via Docker wrapper (image may be amd64-only on ARM64)
+  check_exec "/usr/local/bin/auto-archiver" "auto-archiver launcher"
+
+  # Opt-in tools: absence is a clean pass, not a failure
+  if has archivebox; then
+    show_ver archivebox version || ok "archivebox present"
+  else
+    ok "ArchiveBox not installed (opt-in via TLOSINT_INSTALL_ARCHIVEBOX=1)"
+  fi
+  if has twscrape; then
+    ok "twscrape present: $(command -v twscrape)"
+  else
+    ok "twscrape not installed (opt-in via TLOSINT_ENABLE_TWSCRAPE=1; pending ToS review)"
+  fi
+
   has domainfy && ok "osrframework present (domainfy: $(command -v domainfy))" || warn "osrframework not found"
   has onionsearch && ok "onionsearch present" || warn "onionsearch not found"
   has photon && ok "photon present" || warn "photon not found"

--- a/scripts/tlosint-tools.sh
+++ b/scripts/tlosint-tools.sh
@@ -41,12 +41,18 @@ symlink_if_exists() { local SRC="$1" DEST_NAME="$2"; [[ -x "$SRC" ]] || return 0
 
 ensure_global_symlinks() {
   local CARGODIR="${TARGET_HOME}/.cargo/bin"
-  for b in cargo rustc rustup sn0int; do
+  for b in cargo rustc rustup sn0int monolith; do
     command -v "$b" >/dev/null 2>&1 || symlink_if_exists "${CARGODIR}/${b}" "${b}"
   done
 }
 ensure_pipx_wrappers() {
-  local bins=(shodan sherlock metagoofil sublist3r sf.py)
+  # Binary names (not pipx package names): internetarchive ships `ia`,
+  # WhatsMyName-Python ships `whatsmyname`. Absent binaries are skipped, so the
+  # opt-in tools (archivebox, twscrape) are safe to list unconditionally.
+  local bins=(shodan sherlock metagoofil sublist3r sf.py
+              maigret whatsmyname instaloader ghunt
+              yt-dlp gallery-dl streamlink
+              ia carbon14 archivebox twscrape)
   for b in "${bins[@]}"; do
     [[ -x "${TARGET_HOME}/.local/bin/${b}" ]] && write_wrapper "/usr/local/bin/${b}" "${TARGET_HOME}/.local/bin/${b}"
   done
@@ -96,6 +102,14 @@ install_base_packages() {
     whiptail zenity chromium nodejs npm firefox-esr
     steghide stegseek
     translate-shell
+    # SOCMINT support (issue #191). ffmpeg MUST land before yt-dlp/streamlink:
+    # without it yt-dlp silently returns single-stream (lower quality) media
+    # instead of merging best video+audio. main() runs install_base_packages
+    # before install_tools_from_list, so that ordering is already guaranteed.
+    ffmpeg
+    tesseract-ocr tesseract-ocr-eng
+    mat2
+    httrack
   )
   local p
   for p in "${pkgs[@]}"; do
@@ -158,7 +172,20 @@ pipx_user_install_or_upgrade() {
 go_install_if_missing() {
   local module="$1" ; local bin="${2:-}" ; local name="$bin"
   if [[ -z "$name" ]]; then name="${module##*/}"; name="${name%@*}"; fi
-  if ! command -v "$name" >/dev/null 2>&1; then run "env GOBIN=/usr/local/bin go install \"$module\""; fi
+  command -v "$name" >/dev/null 2>&1 && return 0
+  # Build into a writable temp dir, then place the binary with elevated rights.
+  # Pointing GOBIN straight at /usr/local/bin fails with "permission denied"
+  # whenever this script is run from an unprivileged account, and building under
+  # sudo instead would discard the user's module/toolchain cache.
+  local tmp; tmp="$(mktemp -d)"
+  if run "env GOBIN=\"${tmp}\" go install \"$module\"" && [[ -x "${tmp}/${name}" ]]; then
+    ${SUDO} install -m 0755 "${tmp}/${name}" "/usr/local/bin/${name}" 2>>"$LOG_FILE" \
+      && log "[*] ${name} installed: /usr/local/bin/${name}" \
+      || logerr "Failed to install ${name} into /usr/local/bin"
+  else
+    logerr "go install failed for ${module}"
+  fi
+  rm -rf "$tmp" || true
 }
 cargo_install_if_missing() { local crate="$1"; if ! command -v "$crate" >/dev/null 2>&1; then run "${SUDO} -u \"$TARGET_USER\" bash -lc 'cargo install --locked ${crate}'"; fi; }
 
@@ -261,6 +288,72 @@ EOF
   ${SUDO} chmod 0755 /usr/local/bin/metagoofil
 
   log "[*] Metagoofil installed (wrapper: /usr/local/bin/metagoofil)"
+}
+
+# ---------- auto-archiver (Docker) ----------
+# Upstream ships a maintained image rather than a pip package suited to a VM
+# install, so mirror the Owlculus pattern: pull the image and expose a thin
+# wrapper that mounts the caller's cwd at /data for output.
+install_auto_archiver_docker() {
+  log "[*] Installing bellingcat/auto-archiver (Docker)"
+
+  install_docker_and_compose_if_missing
+
+  if ! command -v docker >/dev/null 2>&1; then
+    logerr "auto-archiver skipped: docker unavailable"
+    return 0
+  fi
+
+  run "${SUDO} docker pull bellingcat/auto-archiver" \
+    || logerr "auto-archiver image pull failed (wrapper still installed; retry via osint-updater)"
+
+  ${SUDO} tee /usr/local/bin/auto-archiver >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# The current directory is mounted at /data inside the container; point
+# auto-archiver's config and output paths there.
+# Only allocate a TTY when there is one, so piping/redirecting still works.
+# Note: an `[[ ... ]] && ...` one-liner would abort under `set -e` whenever the
+# test fails, so branch explicitly.
+TTY_FLAGS=(-i)
+if [[ -t 0 && -t 1 ]]; then
+  TTY_FLAGS=(-i -t)
+fi
+exec docker run --rm "${TTY_FLAGS[@]}" -v "${PWD}:/data" bellingcat/auto-archiver "$@"
+EOF
+  ${SUDO} chmod 0755 /usr/local/bin/auto-archiver
+  ${SUDO} chown root:root /usr/local/bin/auto-archiver
+
+  log "[*] auto-archiver installed (wrapper: /usr/local/bin/auto-archiver)"
+}
+
+# ---------- ArchiveBox (opt-in) ----------
+# ArchiveBox pulls a large dependency tree plus its own Chromium, so it is
+# gated to keep the default VM image small.
+install_archivebox_optional() {
+  if [[ "${TLOSINT_INSTALL_ARCHIVEBOX:-0}" != "1" ]]; then
+    log "[*] ArchiveBox skipped (VM image size; set TLOSINT_INSTALL_ARCHIVEBOX=1 to install)"
+    return 0
+  fi
+  log "[*] Installing ArchiveBox (TLOSINT_INSTALL_ARCHIVEBOX=1)"
+  pipx_user_install_or_upgrade "archivebox" "archivebox"
+  [[ -x "${TARGET_HOME}/.local/bin/archivebox" ]] \
+    && write_wrapper "/usr/local/bin/archivebox" "${TARGET_HOME}/.local/bin/archivebox"
+}
+
+# ---------- twscrape (opt-in, policy-gated) ----------
+# twscrape works by driving logged-in X/Twitter accounts, which plausibly meets
+# the "violation of terms of service" disqualifier in docs/TOOLING_POLICY.md.
+# Left out of the default install pending a Trace Labs policy decision.
+install_twscrape_optional() {
+  if [[ "${TLOSINT_ENABLE_TWSCRAPE:-0}" != "1" ]]; then
+    log "[*] twscrape skipped — pending Trace Labs ToS review (docs/TOOLING_POLICY.md); set TLOSINT_ENABLE_TWSCRAPE=1 to install"
+    return 0
+  fi
+  log "[*] Installing twscrape (TLOSINT_ENABLE_TWSCRAPE=1 — operator accepted ToS risk)"
+  pipx_user_install_or_upgrade "twscrape" "git+https://github.com/vladkens/twscrape.git"
+  [[ -x "${TARGET_HOME}/.local/bin/twscrape" ]] \
+    && write_wrapper "/usr/local/bin/twscrape" "${TARGET_HOME}/.local/bin/twscrape"
 }
 
 # ---------- translate-shell (trans) ----------
@@ -537,6 +630,21 @@ maybe_init_shodan() {
   fi
 }
 
+# ---------- GHunt helper ----------
+# GHunt needs Google account cookies, which cannot be provisioned unattended.
+# Follow the Shodan precedent: install unconditionally, drop a marker so the
+# validator reports "deferred" rather than failing an otherwise-clean install.
+maybe_defer_ghunt_login() {
+  command -v ghunt >/dev/null 2>&1 || return 0
+  if [[ -d "${TARGET_HOME}/.malfrats/ghunt" ]]; then
+    log "[*] GHunt credentials already present"
+    return 0
+  fi
+  ${SUDO} mkdir -p /etc/osint 2>>"$LOG_FILE" || true
+  ${SUDO} bash -lc 'echo "no-credentials" > /etc/osint/skip-ghunt-login' 2>>"$LOG_FILE" || true
+  log "[*] GHunt login deferred (run: ghunt login)"
+}
+
 # ---------- install tools ----------
 install_tools_from_list() {
   log "[*] Installing OSINT tools"
@@ -578,6 +686,37 @@ install_tools_from_list() {
   apt_try_install steghide || true
   apt_try_install stegseek || true
 
+  # ---------- SOCMINT (issue #191) ----------
+  # apt-sourced members of this set (ffmpeg, tesseract-ocr, mat2, httrack) are
+  # handled in install_base_packages, which main() runs first.
+
+  # 1 · Username & account enumeration
+  pipx_user_install_or_upgrade "maigret" "maigret"
+  pipx_user_install_or_upgrade "whatsmyname-python" "git+https://github.com/C3n7ral051nt4g3ncy/WhatsMyName-Python.git"
+
+  # 2 · Platform-specific collection
+  pipx_user_install_or_upgrade "instaloader" "instaloader"
+  pipx_user_install_or_upgrade "ghunt" "ghunt"
+
+  # 3 · Media & evidence acquisition (ffmpeg from base packages)
+  pipx_user_install_or_upgrade "yt-dlp" "yt-dlp"
+  pipx_user_install_or_upgrade "gallery-dl" "gallery-dl"
+  pipx_user_install_or_upgrade "streamlink" "streamlink"
+
+  # 4 · Capture & archiving
+  pipx_user_install_or_upgrade "internetarchive" "internetarchive"   # provides `ia`
+  pipx_user_install_or_upgrade "carbon14" "git+https://github.com/Lazza/Carbon14.git"
+  cargo_install_if_missing "monolith"
+  # gowitness drives the chromium already in install_base_packages.
+  if command -v go >/dev/null 2>&1; then
+    go_install_if_missing "github.com/sensepost/gowitness@latest" "gowitness"
+  fi
+  install_auto_archiver_docker
+  install_archivebox_optional
+
+  # Opt-in / policy-gated
+  install_twscrape_optional
+
   # translate-shell
   install_translate_shell
 
@@ -597,6 +736,9 @@ install_tools_from_list() {
 
   # Shodan init (auto if env; otherwise defer cleanly)
   maybe_init_shodan
+
+  # GHunt needs Google cookies; defer like Shodan rather than failing
+  maybe_defer_ghunt_login
 }
 
 
@@ -622,8 +764,17 @@ apt_self_heal_update() {
   run "apt-get -y clean || true"
 }
 upgrade_pipx_tools() {
-  if command -v pipx >/dev/null 2>&1; then
-    log "[*] Upgrading pipx apps"
+  # This script runs as root (pkexec), but the pipx apps live in the target
+  # user's ~/.local/pipx — root's own pipx home is empty, so the upgrade has to
+  # be run as that user or it silently upgrades nothing. __TARGET_USER__ is
+  # substituted at install time.
+  local PIPX_USER="__TARGET_USER__"
+  if sudo -u "$PIPX_USER" bash -lc 'command -v pipx >/dev/null 2>&1'; then
+    log "[*] Upgrading pipx apps for ${PIPX_USER}"
+    run "sudo -u \"$PIPX_USER\" bash -lc 'pipx upgrade-all' || true"
+    run "sudo -u \"$PIPX_USER\" bash -lc 'pipx runpip shodan install -U setuptools pip wheel' || true"
+  elif command -v pipx >/dev/null 2>&1; then
+    log "[*] Upgrading pipx apps (root)"
     run "pipx upgrade-all || true"
     run "pipx runpip shodan install -U setuptools pip wheel || true"
   fi
@@ -633,17 +784,30 @@ upgrade_go_tools() {
     log "[*] Refreshing PhoneInfoga (Go)"
     run "env GOBIN=/usr/local/bin go install github.com/sundowndev/phoneinfoga/v2/cmd/phoneinfoga@latest"
     chmod 0755 /usr/local/bin/phoneinfoga 2>>"$LOG_FILE" || true
+    log "[*] Refreshing gowitness (Go)"
+    run "env GOBIN=/usr/local/bin go install github.com/sensepost/gowitness@latest || true"
+    chmod 0755 /usr/local/bin/gowitness 2>>"$LOG_FILE" || true
   fi
 }
 upgrade_rust_tools() {
   if command -v cargo >/dev/null 2>&1; then
     log "[*] Refreshing sn0int (Rust)"
     run "cargo install --locked sn0int"
+    log "[*] Refreshing monolith (Rust)"
+    run "cargo install --locked monolith || true"
   fi
 }
-main(){ log "==== OSINT Updater starting ===="; apt_self_heal_update; upgrade_pipx_tools; upgrade_go_tools; upgrade_rust_tools; log "==== OSINT Updater complete. See $LOG_FILE for details. ===="; }
+upgrade_docker_images() {
+  if command -v docker >/dev/null 2>&1; then
+    log "[*] Refreshing auto-archiver image"
+    run "docker pull bellingcat/auto-archiver || true"
+  fi
+}
+main(){ log "==== OSINT Updater starting ===="; apt_self_heal_update; upgrade_pipx_tools; upgrade_go_tools; upgrade_rust_tools; upgrade_docker_images; log "==== OSINT Updater complete. See $LOG_FILE for details. ===="; }
 main "$@"
 EOF
+  # Bake the target user into the updater (same placeholder trick as write_wrapper)
+  ${SUDO} sed -i "s#__TARGET_USER__#${TARGET_USER}#g" "$UPD"
   ${SUDO} chmod +x "$UPD"
   ${SUDO} chown root:root "$UPD"
 
@@ -741,7 +905,11 @@ JSON
 post_install_checks() {
   log "[*] Post-install sanity checks"
   local missing=()
-  for b in shodan sherlock phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide; do
+  # Unconditional tools only — the opt-in pair (archivebox, twscrape) must not
+  # be reported missing on a default install.
+  for b in shodan sherlock phoneinfoga sn0int metagoofil sublist3r exiftool tor trans steghide \
+           maigret whatsmyname instaloader ghunt yt-dlp gallery-dl streamlink \
+           ia carbon14 monolith gowitness ffmpeg tesseract mat2 httrack; do
     command -v "$b" >/dev/null 2>&1 || missing+=("$b")
   done
   command -v spiderfoot >/dev/null 2>&1 || command -v sf.py >/dev/null 2>&1 || missing+=("spiderfoot/sf.py")
@@ -767,6 +935,30 @@ Usage:
                    steghide extract -sf out.jpg
 - StegSeek:        stegseek out.jpg /usr/share/wordlists/rockyou.txt
 - Translate:       trans -b :de "Hello, how are you?"
+
+SOCMINT:
+- maigret:         maigret <username> --html
+- WhatsMyName:     whatsmyname -u <username>
+- Instaloader:     instaloader profile <handle>
+- GHunt:           ghunt login        (then: ghunt email <address>)
+- yt-dlp:          yt-dlp <url>       (ffmpeg present: merges best video+audio)
+- gallery-dl:      gallery-dl <url>
+- streamlink:      streamlink <url> best -o capture.ts
+- monolith:        monolith <url> -o profile.html
+- gowitness:       gowitness scan file -f urls.txt
+- internetarchive: ia search '<query>'   /   ia download <identifier>
+- Carbon14:        carbon14 <url>
+- tesseract:       tesseract image.png out && cat out.txt
+- mat2:            mat2 --inplace evidence.jpg
+- HTTrack:         httrack <url> -O ./mirror
+- auto-archiver:   auto-archiver --help   (Docker; your cwd is mounted at /data)
+- shred:           shred -u <file>        (secure delete; from coreutils)
+
+Opt-in tools (not installed by default):
+- ArchiveBox:      TLOSINT_INSTALL_ARCHIVEBOX=1 sudo -E ./tlosint-tools.sh
+                   (large dependency tree + its own Chromium)
+- twscrape:        TLOSINT_ENABLE_TWSCRAPE=1 sudo -E ./tlosint-tools.sh
+                   (drives logged-in X accounts — review docs/TOOLING_POLICY.md first)
 
 Firefox:
 - about:policies shows hardened settings; OSINT bookmarks on toolbar.
@@ -894,6 +1086,50 @@ validator() {
   show_ver tor --version || true
   show_ver torbrowser-launcher --help || true
   show_ver trans -V || true
+
+  # ---------- SOCMINT (issue #191) ----------
+  show_ver maigret --version || true
+  show_ver whatsmyname --help || true
+  show_ver instaloader --version || true
+  show_ver yt-dlp --version || true
+  show_ver gallery-dl --version || true
+  show_ver streamlink --version || true
+  show_ver ffmpeg -version || true
+  show_ver ia --version || true
+  show_ver monolith --version || true
+  show_ver gowitness version || true
+  show_ver carbon14 --help || true
+  show_ver tesseract --version || true
+  show_ver mat2 --version || true
+  show_ver httrack --version || true
+
+  # GHunt: credential-dependent, same treatment as Shodan above
+  if has ghunt; then
+    if [[ -d "${REAL_HOME}/.malfrats/ghunt" ]]; then
+      ok "GHunt present and authenticated"
+    elif [[ -f /etc/osint/skip-ghunt-login ]]; then
+      ok "GHunt login deferred (no credentials provided; run: ghunt login)"
+    else
+      warn "GHunt not authenticated (run: ghunt login)"
+    fi
+  else
+    fail "ghunt not found on PATH"
+  fi
+
+  # auto-archiver runs via Docker wrapper
+  check_exec "/usr/local/bin/auto-archiver" "auto-archiver launcher"
+
+  # Opt-in tools: absence is a clean pass, not a failure
+  if has archivebox; then
+    show_ver archivebox version || ok "archivebox present"
+  else
+    ok "ArchiveBox not installed (opt-in via TLOSINT_INSTALL_ARCHIVEBOX=1)"
+  fi
+  if has twscrape; then
+    ok "twscrape present: $(command -v twscrape)"
+  else
+    ok "twscrape not installed (opt-in via TLOSINT_ENABLE_TWSCRAPE=1; pending ToS review)"
+  fi
 
   check_exec "/usr/local/bin/osint-updater" "osint-updater"
   check_file "${REAL_HOME}/Desktop/OSINT-Updater.desktop" "OSINT-Updater.desktop"


### PR DESCRIPTION
## Summary

Adds the SOCMINT toolset from #191 to both install scripts (`tlosint-tools.sh` and `tlosint-tools-debian-arm64.sh`), plus matching documentation.

17 tools are installed by default across the six categories in the issue; 2 are gated behind opt-in environment variables.

| Category | Tools | Source |
|---|---|---|
| 1 · Username & account enumeration | maigret, WhatsMyName-Python | pipx |
| 2 · Platform-specific collection | Instaloader, GHunt | pipx |
| 3 · Media & evidence acquisition | yt-dlp, gallery-dl, Streamlink, **ffmpeg** | pipx / apt |
| 4 · Capture & archiving | auto-archiver, monolith, gowitness, internetarchive (`ia`), Carbon14, HTTrack | Docker / cargo / go / pipx / apt |
| 5 · Signal extraction | tesseract-ocr | apt |
| 6 · Investigator OPSEC | mat2 | apt |

**Opt-in, off by default:**

- **ArchiveBox**: install with `TLOSINT_INSTALL_ARCHIVEBOX=1`. 
- **twscrape**: install with `TLOSINT_ENABLE_TWSCRAPE=1`. 

### Notable implementation details

- ffmpeg is added to `install_base_packages()` so it installs before the things that depend on it
- **GHunt credentials** follow the existing Shodan precedent: installed unconditionally, login deferred via an `/etc/osint/skip-ghunt-login` marker, and the validator reports "deferred" rather than failing a clean install.
- **`osint-updater`** now also refreshes gowitness (Go), monolith (Rust), and the auto-archiver Docker image.
- **arm64:** yt-dlp and Instaloader moved from apt to pipx. Trixie's apt builds lag well behind upstream for fast-moving scrapers, and this brings arm64 in line with the amd64 script. The auto-archiver image pull is non-fatal on arm64 in case upstream has no `linux/arm64` manifest.
- **Two incidental fixes** were needed to make the above work (see *Additional context*).

## Type of change

- [ ] Enhancement / improvement
- [x] New OSINT Tool <!-- README updated below -->
- [ ] Bug fix
- [ ] Documentation
- [ ] CI / tooling / refactor

## Related issue(s)

- Closes #191

## Testing

Both install scripts were run end to end on their respective light VM builds, and the validation step was checked afterwards. There's some stuff to fix on the arm64 install script but it's unrelated to this PR. Mostly torbrowser doesn't have an arm64 installation candidate in `apt`.

## Additional context

Also found and fixed two bugs while I was in here.

1. **`go_install_if_missing()` permission failure.** It pointed `GOBIN` straight at `/usr/local/bin`, which fails with "permission denied" when the script is run from an unprivileged account. It now builds into a temp dir and installs the binary with elevated rights, which preserves the user's module cache (building under sudo would discard it). This affected PhoneInfoga already, trying to install gowitness just make it noticeable.
2. **`osint-updater` upgraded nothing via pipx.** The updater runs as root under pkexec, but the pipx apps live in the target user's `~/.local/pipx`, so `pipx upgrade-all` as root silently found nothing to do. The target user is now baked in at install time using the same `__TARGET_USER__` placeholder trick as `write_wrapper`, and the upgrade runs as that user.

**Docs updated:**
- `README.md`: new SOCMINT line in the feature list, an "Optional tools (opt-in)" section with the env-var invocations, new "Capture & Archiving" and "Investigator OPSEC" tool-list sections, and additions to Data Analysis / Downloaders / Social Media / Usernames. Also corrected the stale youtube-dl link to yt-dlp.
- `VM Tool Reference.md`: new sections with usage examples for every tool added. Updated in **both** copies (`etc/skel/Desktop/TL-Vault/` and `usr/share/Obsidian/TL-Obsidian-Template/`); the two files are byte-identical.
- `usage_hints()` in both scripts: SOCMINT usage block, an opt-in tools block, and a `shred` line (noted in #191 as already present via coreutils but undocumented).